### PR TITLE
HTMLを解析する処理を別クラスに切り出す

### DIFF
--- a/lib/bill_parser.rb
+++ b/lib/bill_parser.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+class BillParser
+  BILLS_URI_PREFIX ="http://www.shugiin.go.jp/internet/itdb_gian.nsf/html/gian/"
+  PROPOSERS = {
+    representatives: { name: "衆議院", id: "05", type: "衆法" },
+    counsillors: { name: "参議院", id: "06", type: "参法" },
+    ministry: { name: "内閣", id: "09", type: "閣法" }
+  }
+
+  def initialize(page)
+    @page = page
+  end
+
+  def parse_bills
+    PROPOSERS.flat_map do |key, proposer|
+      table = bills_table(proposer[:type])
+      bill_info(table, proposer)
+    end
+  end
+
+  private
+    def bills_table(bill_type)
+      @page
+        .scan(%r{#{bill_type}の一覧</caption>.*?</table>}m)
+        .join
+        .scan(%r{<tr.*?</tr>}m)
+        .tap(&:shift)
+    end
+
+    def bill_info(table, proposer)
+      table.map do |row|
+        fields = row.scan(%r{<td.*?</td>}m)
+        contents = fields.map { content_in_cell(_1) }
+        {
+          submitted_session_number: contents[0],
+          bill_number:              contents[1],
+          title:                    contents[2],
+          proposer:                 proposer[:name],
+          discussed_session_number: latest_session_number,
+          proposal:                 proposal_url(contents[0], proposer[:id], contents[1]),
+          outline:                  outline_url(contents[0], proposer[:id], contents[1]),
+          status:                   contents[3]
+        }
+      end
+    end
+
+    def latest_session_number
+      @page.match(%r{<H2.*?(\d{1,3}).*?</H2>}).captures[0]
+    end
+
+    def content_in_cell(cell)
+      cell.match(%r{<span.*?>(.*?)</span>}).captures[0]
+    end
+
+    def proposal_url(submitted_session_number, proposer_id, bill_number)
+      BILLS_URI_PREFIX + "honbun/houan/g" + bill_page_number(submitted_session_number, proposer_id, bill_number) + ".htm"
+    end
+
+    def outline_url(submitted_session_number, proposer_id, bill_number)
+      BILLS_URI_PREFIX + "youkou/g" + bill_page_number(submitted_session_number, proposer_id, bill_number) + ".htm"
+    end
+
+    def bill_page_number(submitted_session_number, proposer_id, bill_number)
+      align_to_3_digits(submitted_session_number) + proposer_id + align_to_3_digits(bill_number)
+    end
+
+    def align_to_3_digits(number)
+      number.rjust(3, "0")
+    end
+end

--- a/lib/bill_parser.rb
+++ b/lib/bill_parser.rb
@@ -12,7 +12,7 @@ class BillParser
     @page = page
   end
 
-  def parse_bills
+  def bills
     PROPOSERS.flat_map do |key, proposer|
       table = bills_table(proposer[:type])
       bill_info(table, proposer)

--- a/lib/bill_parser.rb
+++ b/lib/bill_parser.rb
@@ -15,7 +15,7 @@ class BillParser
   def bills
     PROPOSERS.flat_map do |key, proposer|
       table = bills_table(proposer[:type])
-      bill_info(table, proposer)
+      bill_info(table, proposer[:name], proposer[:id])
     end
   end
 
@@ -28,7 +28,7 @@ class BillParser
         .tap(&:shift)
     end
 
-    def bill_info(table, proposer)
+    def bill_info(table, proposer_name, proposer_id)
       table.map do |row|
         fields = row.scan(%r{<td.*?</td>}m)
         contents = fields.map { content_in_cell(_1) }
@@ -36,10 +36,10 @@ class BillParser
           submitted_session_number: contents[0],
           bill_number:              contents[1],
           title:                    contents[2],
-          proposer:                 proposer[:name],
+          proposer:                 proposer_name,
           discussed_session_number: latest_session_number,
-          proposal:                 proposal_url(contents[0], proposer[:id], contents[1]),
-          outline:                  outline_url(contents[0], proposer[:id], contents[1]),
+          proposal:                 proposal_url(contents[0], proposer_id, contents[1]),
+          outline:                  outline_url(contents[0], proposer_id, contents[1]),
           status:                   contents[3]
         }
       end

--- a/lib/bill_parser.rb
+++ b/lib/bill_parser.rb
@@ -13,13 +13,13 @@ class BillParser
 
   def bills
     PROPOSERS.flat_map do |key, proposer|
-      rows = bill_rows(proposer[:type])
-      bill_info(rows, proposer[:name], proposer[:id])
+      rows = table_rows_without_header(proposer[:type])
+      build_bills(rows, proposer[:name], proposer[:id])
     end
   end
 
   private
-    def bill_rows(bill_type)
+    def table_rows_without_header(bill_type)
       table = extract_table(@page, bill_type)
       rows = extract_rows(table)
       delete_header(rows)
@@ -37,28 +37,35 @@ class BillParser
       rows.tap(&:shift)
     end
 
-    def bill_info(rows, proposer_name, proposer_id)
+    def build_bills(rows, proposer_name, proposer_id)
       rows.map do |row|
-        fields = row.scan(%r{<td.*?</td>}m)
-        contents = fields.map { content_in_cell(_1) }
-        {
-          submitted_session_number: contents[0],
-          bill_number:              contents[1],
-          title:                    contents[2],
-          proposer:                 proposer_name,
-          discussed_session_number: latest_session_number,
-          proposal:                 BillUri.proposal_url(contents[0], proposer_id, contents[1]),
-          outline:                  BillUri.outline_url(contents[0], proposer_id, contents[1]),
-          status:                   contents[3]
-        }
+        contents = extract_fields(row).map { content_in_field(_1) }
+        bill_info_from(contents, proposer_name, proposer_id)
       end
+    end
+
+    def bill_info_from(contents, proposer_name, proposer_id)
+      {
+        submitted_session_number: contents[0],
+        bill_number:              contents[1],
+        title:                    contents[2],
+        proposer:                 proposer_name,
+        discussed_session_number: latest_session_number,
+        proposal:                 BillUri.proposal_url(contents[0], proposer_id, contents[1]),
+        outline:                  BillUri.outline_url(contents[0], proposer_id, contents[1]),
+        status:                   contents[3]
+      }
+    end
+
+    def extract_fields(row)
+      row.scan(%r{<td.*?</td>}m)
     end
 
     def latest_session_number
       @page.match(%r{<H2.*?(\d{1,3}).*?</H2>}).captures[0]
     end
 
-    def content_in_cell(cell)
-      cell.match(%r{<span.*?>(.*?)</span>}).captures[0]
+    def content_in_field(field)
+      field.match(%r{<span.*?>(.*?)</span>}).captures[0]
     end
 end

--- a/lib/bill_parser.rb
+++ b/lib/bill_parser.rb
@@ -7,65 +7,63 @@ class BillParser
     ministry: { name: "内閣", id: "09", type: "閣法" }
   }
 
-  def initialize(page)
-    @page = page
-  end
-
-  def bills
-    PROPOSERS.flat_map do |key, proposer|
-      rows = table_rows_without_header(proposer[:type])
-      build_bills(rows, proposer[:name], proposer[:id])
-    end
-  end
-
-  private
-    def table_rows_without_header(bill_type)
-      table = extract_table(@page, bill_type)
-      rows = extract_rows(table)
-      delete_header(rows)
-    end
-
-    def extract_table(page, bill_type)
-      page.scan(%r{#{bill_type}の一覧</caption>.*?</table>}m).join
-    end
-
-    def extract_rows(table)
-      table.scan(%r{<tr.*?</tr>}m)
-    end
-
-    def delete_header(rows)
-      rows.tap(&:shift)
-    end
-
-    def build_bills(rows, proposer_name, proposer_id)
-      rows.map do |row|
-        contents = extract_fields(row).map { content_in_field(_1) }
-        bill_info_from(contents, proposer_name, proposer_id)
+  class << self
+    def bills(page)
+      PROPOSERS.flat_map do |key, proposer|
+        rows = table_rows_without_header(page, proposer[:type])
+        build_bills(rows, proposer[:name], proposer[:id], page)
       end
     end
 
-    def bill_info_from(contents, proposer_name, proposer_id)
-      {
-        submitted_session_number: contents[0],
-        bill_number:              contents[1],
-        title:                    contents[2],
-        proposer:                 proposer_name,
-        discussed_session_number: latest_session_number,
-        proposal:                 BillUri.proposal_url(contents[0], proposer_id, contents[1]),
-        outline:                  BillUri.outline_url(contents[0], proposer_id, contents[1]),
-        status:                   contents[3]
-      }
-    end
+    private
+      def table_rows_without_header(page, bill_type)
+        table = extract_table(page, bill_type)
+        rows = extract_rows(table)
+        delete_header(rows)
+      end
 
-    def extract_fields(row)
-      row.scan(%r{<td.*?</td>}m)
-    end
+      def extract_table(page, bill_type)
+        page.scan(%r{#{bill_type}の一覧</caption>.*?</table>}m).join
+      end
 
-    def latest_session_number
-      @page.match(%r{<H2.*?(\d{1,3}).*?</H2>}).captures[0]
-    end
+      def extract_rows(table)
+        table.scan(%r{<tr.*?</tr>}m)
+      end
 
-    def content_in_field(field)
-      field.match(%r{<span.*?>(.*?)</span>}).captures[0]
-    end
+      def delete_header(rows)
+        rows.tap(&:shift)
+      end
+
+      def build_bills(rows, proposer_name, proposer_id, page)
+        rows.map do |row|
+          contents = extract_fields(row).map { content_in_field(_1) }
+          bill_info_from(contents, proposer_name, proposer_id, page)
+        end
+      end
+
+      def bill_info_from(contents, proposer_name, proposer_id, page)
+        {
+          submitted_session_number: contents[0],
+          bill_number:              contents[1],
+          title:                    contents[2],
+          proposer:                 proposer_name,
+          discussed_session_number: latest_session_number(page),
+          proposal:                 BillUri.proposal_url(contents[0], proposer_id, contents[1]),
+          outline:                  BillUri.outline_url(contents[0], proposer_id, contents[1]),
+          status:                   contents[3]
+        }
+      end
+
+      def extract_fields(row)
+        row.scan(%r{<td.*?</td>}m)
+      end
+
+      def latest_session_number(page)
+        page.match(%r{<H2.*?(\d{1,3}).*?</H2>}).captures[0]
+      end
+
+      def content_in_field(field)
+        field.match(%r{<span.*?>(.*?)</span>}).captures[0]
+      end
+  end
 end

--- a/lib/bill_parser.rb
+++ b/lib/bill_parser.rb
@@ -47,8 +47,8 @@ class BillParser
           title:                    contents[2],
           proposer:                 proposer_name,
           discussed_session_number: latest_session_number,
-          proposal:                 BillUris.proposal_url(contents[0], proposer_id, contents[1]),
-          outline:                  BillUris.outline_url(contents[0], proposer_id, contents[1]),
+          proposal:                 BillUri.proposal_url(contents[0], proposer_id, contents[1]),
+          outline:                  BillUri.outline_url(contents[0], proposer_id, contents[1]),
           status:                   contents[3]
         }
       end

--- a/lib/bill_parser.rb
+++ b/lib/bill_parser.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class BillParser
-  BILLS_URI_PREFIX ="http://www.shugiin.go.jp/internet/itdb_gian.nsf/html/gian/"
   PROPOSERS = {
     representatives: { name: "衆議院", id: "05", type: "衆法" },
     counsillors: { name: "参議院", id: "06", type: "参法" },
@@ -38,8 +37,8 @@ class BillParser
           title:                    contents[2],
           proposer:                 proposer_name,
           discussed_session_number: latest_session_number,
-          proposal:                 proposal_url(contents[0], proposer_id, contents[1]),
-          outline:                  outline_url(contents[0], proposer_id, contents[1]),
+          proposal:                 BillUris.proposal_url(contents[0], proposer_id, contents[1]),
+          outline:                  BillUris.outline_url(contents[0], proposer_id, contents[1]),
           status:                   contents[3]
         }
       end
@@ -51,21 +50,5 @@ class BillParser
 
     def content_in_cell(cell)
       cell.match(%r{<span.*?>(.*?)</span>}).captures[0]
-    end
-
-    def proposal_url(submitted_session_number, proposer_id, bill_number)
-      BILLS_URI_PREFIX + "honbun/houan/g" + bill_page_number(submitted_session_number, proposer_id, bill_number) + ".htm"
-    end
-
-    def outline_url(submitted_session_number, proposer_id, bill_number)
-      BILLS_URI_PREFIX + "youkou/g" + bill_page_number(submitted_session_number, proposer_id, bill_number) + ".htm"
-    end
-
-    def bill_page_number(submitted_session_number, proposer_id, bill_number)
-      align_to_3_digits(submitted_session_number) + proposer_id + align_to_3_digits(bill_number)
-    end
-
-    def align_to_3_digits(number)
-      number.rjust(3, "0")
     end
 end

--- a/lib/bill_parser.rb
+++ b/lib/bill_parser.rb
@@ -11,7 +11,7 @@ class BillParser
     def bills(page)
       PROPOSERS.flat_map do |key, proposer|
         rows = table_rows_without_header(page, proposer[:type])
-        build_bills(rows, proposer[:name], proposer[:id], page)
+        build_bills(rows, proposer[:name], proposer[:id], latest_session_number(page))
       end
     end
 
@@ -34,20 +34,20 @@ class BillParser
         rows.tap(&:shift)
       end
 
-      def build_bills(rows, proposer_name, proposer_id, page)
+      def build_bills(rows, proposer_name, proposer_id, latest_session_number)
         rows.map do |row|
           contents = extract_fields(row).map { content_in_field(_1) }
-          bill_info_from(contents, proposer_name, proposer_id, page)
+          bill_info_from(contents, proposer_name, proposer_id, latest_session_number)
         end
       end
 
-      def bill_info_from(contents, proposer_name, proposer_id, page)
+      def bill_info_from(contents, proposer_name, proposer_id, latest_session_number)
         {
           submitted_session_number: contents[0],
           bill_number:              contents[1],
           title:                    contents[2],
           proposer:                 proposer_name,
-          discussed_session_number: latest_session_number(page),
+          discussed_session_number: latest_session_number,
           proposal:                 BillUri.proposal_url(contents[0], proposer_id, contents[1]),
           outline:                  BillUri.outline_url(contents[0], proposer_id, contents[1]),
           status:                   contents[3]

--- a/lib/bill_scrapper.rb
+++ b/lib/bill_scrapper.rb
@@ -7,7 +7,7 @@ class BillScrapper
 
   class << self
     def latest_discussed_bills
-      BillParser.new(latest_bills_page).parse_bills
+      BillParser.new(latest_bills_page).bills
     end
 
     private

--- a/lib/bill_scrapper.rb
+++ b/lib/bill_scrapper.rb
@@ -5,7 +5,7 @@ require "open-uri"
 class BillScrapper
   class << self
     def latest_discussed_bills
-      BillParser.new(latest_bills_page).bills
+      BillParser.bills(latest_bills_page)
     end
 
     private

--- a/lib/bill_scrapper.rb
+++ b/lib/bill_scrapper.rb
@@ -3,8 +3,6 @@
 require "open-uri"
 
 class BillScrapper
-  LATEST_BILLS_URI ="http://www.shugiin.go.jp/internet/itdb_gian.nsf/html/gian/menu.htm"
-
   class << self
     def latest_discussed_bills
       BillParser.new(latest_bills_page).bills
@@ -12,7 +10,7 @@ class BillScrapper
 
     private
       def latest_bills_page
-        @latest_bills_page ||= URI.open(LATEST_BILLS_URI).read
+        @latest_bills_page ||= URI.open(BillUris::LATEST_BILLS_URI).read
       end
   end
 end

--- a/lib/bill_scrapper.rb
+++ b/lib/bill_scrapper.rb
@@ -3,73 +3,16 @@
 require "open-uri"
 
 class BillScrapper
-  BILLS_URI_PREFIX ="http://www.shugiin.go.jp/internet/itdb_gian.nsf/html/gian/"
-  LATEST_BILLS_URI = BILLS_URI_PREFIX + "menu.htm"
-  PROPOSERS = {
-                representatives: { name: "衆議院", id: "05", type: "衆法" },
-                counsillors: { name: "参議院", id: "06", type: "参法" },
-                ministry: { name: "内閣", id: "09", type: "閣法" }
-              }
+  LATEST_BILLS_URI ="http://www.shugiin.go.jp/internet/itdb_gian.nsf/html/gian/menu.htm"
 
   class << self
     def latest_discussed_bills
-      PROPOSERS.flat_map do |key, proposer|
-        bills_table = bills_in_page(latest_bills_page, proposer[:type])
-        parse_bills(proposer, bills_table)
+      BillParser.new(latest_bills_page).parse_bills
+    end
+
+    private
+      def latest_bills_page
+        @latest_bills_page ||= URI.open(LATEST_BILLS_URI).read
       end
-    end
-
-    def latest_bills_page
-      @latest_bills_page ||= URI.open(LATEST_BILLS_URI).read
-    end
-
-    def latest_session_number
-      latest_bills_page.match(%r{<H2.*?(\d{1,3}).*?</H2>}).captures[0]
-    end
-
-    def bills_in_page(page, bill_type)
-      page
-        .scan(%r{#{bill_type}の一覧</caption>.*?</table>}m)
-        .join
-        .scan(%r{<tr.*?</tr>}m)
-        .tap(&:shift)
-    end
-
-    def parse_bills(proposer, table)
-      table.map do |row|
-        fields = row.scan(%r{<td.*?</td>}m)
-        contents = fields.map { content_in_cell(_1) }
-        {
-          submitted_session_number: contents[0],
-          bill_number:              contents[1],
-          title:                    contents[2],
-          proposer:                 proposer[:name],
-          discussed_session_number: latest_session_number,
-          proposal:                 proposal_url(contents[0], proposer[:id], contents[1]),
-          outline:                  outline_url(contents[0], proposer[:id], contents[1]),
-          status:                   contents[3]
-        }
-      end
-    end
-
-    def content_in_cell(cell)
-      cell.match(%r{<span.*?>(.*?)</span>}).captures[0]
-    end
-
-    def proposal_url(submitted_session_number, proposer_id, bill_number)
-      BILLS_URI_PREFIX + "honbun/houan/g" + bill_page_number(submitted_session_number, proposer_id, bill_number) + ".htm"
-    end
-
-    def outline_url(submitted_session_number, proposer_id, bill_number)
-      BILLS_URI_PREFIX + "youkou/g" + bill_page_number(submitted_session_number, proposer_id, bill_number) + ".htm"
-    end
-
-    def bill_page_number(submitted_session_number, proposer_id, bill_number)
-      align_to_3_digits(submitted_session_number) + proposer_id + align_to_3_digits(bill_number)
-    end
-
-    def align_to_3_digits(number)
-      number.rjust(3, "0")
-    end
   end
 end

--- a/lib/bill_scrapper.rb
+++ b/lib/bill_scrapper.rb
@@ -10,7 +10,7 @@ class BillScrapper
 
     private
       def latest_bills_page
-        @latest_bills_page ||= URI.open(BillUris::LATEST_BILLS_URI).read
+        @latest_bills_page ||= URI.open(BillUri::LATEST_BILLS_URI).read
       end
   end
 end

--- a/lib/bill_uri.rb
+++ b/lib/bill_uri.rb
@@ -12,10 +12,8 @@ class BillUri
     def outline_url(submitted_session_number, proposer_id, bill_number)
       BILLS_URI_PREFIX + "youkou/g" + bill_page_number(submitted_session_number, proposer_id, bill_number) + ".htm"
     end
-  end
 
-  private
-    class << self
+    private
       def bill_page_number(submitted_session_number, proposer_id, bill_number)
         align_to_3_digits(submitted_session_number) + proposer_id + align_to_3_digits(bill_number)
       end
@@ -23,5 +21,5 @@ class BillUri
       def align_to_3_digits(number)
         number.rjust(3, "0")
       end
-    end
+  end
 end

--- a/lib/bill_uri.rb
+++ b/lib/bill_uri.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class BillUris
+class BillUri
   LATEST_BILLS_URI = "http://www.shugiin.go.jp/internet/itdb_gian.nsf/html/gian/menu.htm"
   BILLS_URI_PREFIX = "http://www.shugiin.go.jp/internet/itdb_gian.nsf/html/gian/"
 

--- a/lib/bill_uris.rb
+++ b/lib/bill_uris.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class BillUris
+  LATEST_BILLS_URI = "http://www.shugiin.go.jp/internet/itdb_gian.nsf/html/gian/menu.htm"
+  BILLS_URI_PREFIX = "http://www.shugiin.go.jp/internet/itdb_gian.nsf/html/gian/"
+
+  class << self
+    def proposal_url(submitted_session_number, proposer_id, bill_number)
+      BILLS_URI_PREFIX + "honbun/houan/g" + bill_page_number(submitted_session_number, proposer_id, bill_number) + ".htm"
+    end
+
+    def outline_url(submitted_session_number, proposer_id, bill_number)
+      BILLS_URI_PREFIX + "youkou/g" + bill_page_number(submitted_session_number, proposer_id, bill_number) + ".htm"
+    end
+  end
+
+  private
+    class << self
+      def bill_page_number(submitted_session_number, proposer_id, bill_number)
+        align_to_3_digits(submitted_session_number) + proposer_id + align_to_3_digits(bill_number)
+      end
+
+      def align_to_3_digits(number)
+        number.rjust(3, "0")
+      end
+    end
+end


### PR DESCRIPTION
ref #8 

* 衆議院のサイトの議案一覧ページから法案の情報を抽出する処理を、BillParserクラスとして切り出す。
  * BillScrapperは外部サイトへアクセスして法案リストをBillモデルに渡すだけのクラスとし、実際の解析部分は全てBillParserに処理させる。
  * 一部メソッドは名前がわかりづらいので改名する。