### PR TITLE
過去の会期の議案一覧ページを取得する

### DIFF
--- a/app/lib/bill_scrapper.rb
+++ b/app/lib/bill_scrapper.rb
@@ -21,7 +21,7 @@ class BillScrapper
       end
 
       def extract_session_numbers
-        session_selectbox.scan(/第(\d{3})回/m).flatten
+        session_selectbox.scan(/第(\d{3})回/).flatten
       end
 
       def session_selectbox

--- a/app/lib/bill_scrapper.rb
+++ b/app/lib/bill_scrapper.rb
@@ -9,18 +9,18 @@ class BillScrapper
     end
 
     private
-      def latest_bills_page
+      def latest_bill_page
         @latest_bills_page ||= open_as_SJIS(BillUri::LATEST_BILLS_URI).read
       end
 
-      def old_bills_pages
+      def old_bill_pages
         @old_bills_pages ||=
           BillUri.old_session_urls(extract_session_numbers).map do
             open_as_SJIS(_1).read
           end
       end
 
-      def open_as_SJIS(uri)
+      def open_as_sjis(uri)
         URI.open(uri).set_encoding("Shift_JIS", "Shift_JIS")
       end
 

--- a/app/lib/bill_scrapper.rb
+++ b/app/lib/bill_scrapper.rb
@@ -21,7 +21,7 @@ class BillScrapper
       end
 
       def extract_session_numbers
-        session_selectbox.scan(%r{第(\d{3})回}m).flatten
+        session_selectbox.scan(/第(\d{3})回/m).flatten
       end
 
       def session_selectbox

--- a/app/lib/bill_scrapper.rb
+++ b/app/lib/bill_scrapper.rb
@@ -25,7 +25,7 @@ class BillScrapper
       end
 
       def session_selectbox
-        latest_bill_page.match(%r{<SELECT NAME="kaiji".*?</SELECT>}m).to_s
+        latest_bill_page.slice(%r{<SELECT NAME="kaiji".*?</SELECT>}m)
       end
   end
 end

--- a/app/lib/bill_scrapper.rb
+++ b/app/lib/bill_scrapper.rb
@@ -21,7 +21,11 @@ class BillScrapper
       end
 
       def extract_session_numbers
-        latest_bill_page.scan(%r{<OPTION>.*?回}m).map{ _1.match(%r{\d{3}}m).to_s }
+        session_selectbox.scan(%r{第(\d{3})回}m).flatten
+      end
+
+      def session_selectbox
+        latest_bill_page.match(%r{<SELECT NAME="kaiji".*?</SELECT>}m).to_s
       end
   end
 end

--- a/app/lib/bill_scrapper.rb
+++ b/app/lib/bill_scrapper.rb
@@ -5,16 +5,16 @@ require "open-uri"
 class BillScrapper
   class << self
     def latest_discussed_bills
-      BillParser.bills(latest_bills_page)
+      BillParser.bills(latest_bill_page)
     end
 
     private
       def latest_bill_page
-        @latest_bills_page ||= URI.open(BillUri::LATEST_BILLS_URI).read
+        @latest_bill_page ||= URI.open(BillUri::LATEST_BILLS_URI).read
       end
 
       def old_bill_pages
-        @old_bills_pages ||=
+        @old_bill_pages ||=
           BillUri.old_session_urls(extract_session_numbers).map do
             URI.open(_1).read
           end

--- a/app/lib/bill_scrapper.rb
+++ b/app/lib/bill_scrapper.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true, coding: shift_jis
+# frozen_string_literal: true
 
 require "open-uri"
 
@@ -10,22 +10,18 @@ class BillScrapper
 
     private
       def latest_bill_page
-        @latest_bills_page ||= open_as_SJIS(BillUri::LATEST_BILLS_URI).read
+        @latest_bills_page ||= URI.open(BillUri::LATEST_BILLS_URI).read
       end
 
       def old_bill_pages
         @old_bills_pages ||=
           BillUri.old_session_urls(extract_session_numbers).map do
-            open_as_SJIS(_1).read
+            URI.open(_1).read
           end
       end
 
-      def open_as_sjis(uri)
-        URI.open(uri).set_encoding("Shift_JIS", "Shift_JIS")
-      end
-
       def extract_session_numbers
-        latest_bills_page.scan(%r{<OPTION>.*?��}m).map{ _1.match(%r{\d{3}}m).to_s }
+        latest_bill_page.scan(%r{<OPTION>.*?回}m).map{ _1.match(%r{\d{3}}m).to_s }
       end
   end
 end

--- a/app/lib/bill_scrapper.rb
+++ b/app/lib/bill_scrapper.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+# frozen_string_literal: true, coding: shift_jis
 
 require "open-uri"
 
@@ -10,7 +10,22 @@ class BillScrapper
 
     private
       def latest_bills_page
-        @latest_bills_page ||= URI.open(BillUri::LATEST_BILLS_URI).read
+        @latest_bills_page ||= open_as_SJIS(BillUri::LATEST_BILLS_URI).read
+      end
+
+      def old_bills_pages
+        @old_bills_pages ||=
+          BillUri.old_session_urls(extract_session_numbers).map do
+            open_as_SJIS(_1).read
+          end
+      end
+
+      def open_as_SJIS(uri)
+        URI.open(uri).set_encoding("Shift_JIS", "Shift_JIS")
+      end
+
+      def extract_session_numbers
+        latest_bills_page.scan(%r{<OPTION>.*?��}m).map{ _1.match(%r{\d{3}}m).to_s }
       end
   end
 end

--- a/app/lib/bill_uri.rb
+++ b/app/lib/bill_uri.rb
@@ -5,6 +5,10 @@ class BillUri
   BILLS_URI_PREFIX = "http://www.shugiin.go.jp/internet/itdb_gian.nsf/html/gian/"
 
   class << self
+    def old_session_urls(numbers)
+      numbers.map { BILLS_URI_PREFIX + "kaiji#{_1}.htm" }
+    end
+
     def proposal_url(submitted_session_number, proposer_id, bill_number)
       BILLS_URI_PREFIX + "honbun/houan/g" + bill_page_number(submitted_session_number, proposer_id, bill_number) + ".htm"
     end


### PR DESCRIPTION
ref: #9 

## 概要
* 過去の会期番号から各会期のURIを生成し、順次HTMLを取得して配列に格納する。
* ~~取得するサイトはShift_JISで書かれており、UTF-8に変換できない文字が含まれている場合があるため、Shift_JISのまま取得する。~~
  * ~~具体的には、右記のリンク先の"Ⅸ"が変換できなかった →[第195回  「衆法の一覧」内の"Ⅸ"](http://www.shugiin.go.jp/internet/itdb_gian.nsf/html/gian/kaiji195.htm#05)~~
* ~~正規表現によるマッチングもShift_JISに対応する必要があるため、正規表現を用いた処理が含まれるファイルにはマジックコメント`coding: shift_jis`を追加し、ファイル自体のエンコードをShift_JISに変換する(nkfコマンドを利用)~~
* 衆議院のサイト文字コードはShift_JISだが、参議院はUTF-8。最終的に複数文字コードに対応する必要が出てくるので、変換できない文字列に対しての変換機能を別途実装する

## 参考にしたサイト
* ~~https://docs.ruby-lang.org/ja/latest/doc/spec=2fm17n.html#magic_comment~~
* ~~http://kawatama.net/others/mac/1754~~
