### PR TITLE
Shift_JISからUTF-8に自動変換できない文字列を置換する

### DIFF
--- a/app/lib/bill_scrapper.rb
+++ b/app/lib/bill_scrapper.rb
@@ -34,11 +34,11 @@ class BillScrapper
 
       def convert_undef_chars(encoded_text, unencoded_text)
         encoded_text += as_utf8(unencoded_text)
-        rescue Encoding::UndefinedConversionError
-          undef_char = binary_error_char($!)
+        rescue Encoding::UndefinedConversionError => e
+          undef_char = binary_error_char(e)
           if converted_char = consult_dictionary(undef_char)
             encoded_text += as_utf8(match_error_char(unencoded_text, undef_char).pre_match) + converted_char
-            unencoded_text = match_error_char(unencoded_text, binary_error_char($!)).post_match
+            unencoded_text = match_error_char(unencoded_text, binary_error_char(e)).post_match
             retry
           end
       end

--- a/app/lib/bill_scrapper.rb
+++ b/app/lib/bill_scrapper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "open-uri"
-require "my_dictionary.rb"
+require "my_dictionary"
 
 class BillScrapper
   class << self
@@ -11,7 +11,7 @@ class BillScrapper
 
     private
       def latest_bill_page
-        @latest_bill_pagez ||= safe_read(BillUri::LATEST_BILLS_URI)
+        @latest_bill_page ||= safe_read(BillUri::LATEST_BILLS_URI)
       end
 
       def old_bill_pages

--- a/app/lib/bill_scrapper.rb
+++ b/app/lib/bill_scrapper.rb
@@ -27,13 +27,14 @@ class BillScrapper
       end
 
       def safe_read(uri)
-        encoded_text = ""
         unencoded_text = URI.open(uri, "r:binary").read
-        convert_undef_chars(encoded_text, unencoded_text)
+        convert_undef_chars(unencoded_text)
       end
 
-      def convert_undef_chars(encoded_text, unencoded_text)
-        encoded_text += as_utf8(unencoded_text)
+      def convert_undef_chars(unencoded_text)
+        encoded_text = ""
+        begin
+          encoded_text += as_utf8(unencoded_text)
         rescue Encoding::UndefinedConversionError => e
           undef_char = binary_error_char(e)
           if converted_char = consult_dictionary(undef_char)
@@ -41,6 +42,7 @@ class BillScrapper
             unencoded_text = match_error_char(unencoded_text, binary_error_char(e)).post_match
             retry
           end
+        end
       end
 
       def consult_dictionary(char)

--- a/app/lib/bill_scrapper.rb
+++ b/app/lib/bill_scrapper.rb
@@ -36,18 +36,12 @@ class BillScrapper
         begin
           encoded_text += as_utf8(unencoded_text)
         rescue Encoding::UndefinedConversionError => e
-          undef_char = binary_error_char(e)
-          if converted_char = consult_dictionary(undef_char)
+          undef_char = as_binary(e.error_char)
+          if converted_char = dictionary[undef_char]
             encoded_text += as_utf8(match_error_char(unencoded_text, undef_char).pre_match) + converted_char
-            unencoded_text = match_error_char(unencoded_text, binary_error_char(e)).post_match
+            unencoded_text = match_error_char(unencoded_text, as_binary(e.error_char)).post_match
             retry
           end
-        end
-      end
-
-      def consult_dictionary(char)
-        if dictionary.keys.include? char
-          dictionary[char]
         end
       end
 
@@ -57,10 +51,6 @@ class BillScrapper
 
       def match_error_char(text, binary_error_char)
         text.match(Regexp.compile(binary_error_char + "\\", nil, "n"))
-      end
-
-      def binary_error_char(error)
-        as_binary(error.error_char)
       end
 
       def as_binary(text)

--- a/app/lib/bill_scrapper.rb
+++ b/app/lib/bill_scrapper.rb
@@ -11,11 +11,11 @@ class BillScrapper
 
     private
       def latest_bill_page
-        @latest_bill_page ||= safe_read(BillUri::LATEST_BILLS_URI)
+        @latest_bill_page ||= read_as_utf8(BillUri::LATEST_BILLS_URI)
       end
 
       def old_bill_pages
-        @old_bill_pages ||= BillUri.old_session_urls(extract_session_numbers).map { safe_read(_1) }
+        @old_bill_pages ||= BillUri.old_session_urls(extract_session_numbers).map { read_as_utf8(_1) }
       end
 
       def extract_session_numbers
@@ -26,7 +26,7 @@ class BillScrapper
         latest_bill_page.slice(%r{<SELECT NAME="kaiji".*?</SELECT>}m)
       end
 
-      def safe_read(uri)
+      def read_as_utf8(uri)
         unencoded_text = URI.open(uri, "r:binary").read
         convert_undef_chars(unencoded_text)
       end

--- a/app/lib/my_dictionary.rb
+++ b/app/lib/my_dictionary.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module MyDictionary
+  # Shift_JISからUTF-8に自動変換できない文字。登場次第、順次追記していく。
+  INCOMPATIBLE_CHARS = {
+    "\x87\\".encode("binary", "binary") => "Ⅸ"
+  }
+end


### PR DESCRIPTION
ref: #9

## 概要
* PR #33 から分離
* 衆議院のサイトはShift_JISで書かれており、UTF-8に変換できない文字が含まれている場合があるので、これをUTF-8で表現可能な別の文字列に置換する。
  * 具体的には、右記のリンク先の"Ⅸ"が変換できなかった →[第195回  「衆法の一覧」内の"Ⅸ"](http://www.shugiin.go.jp/internet/itdb_gian.nsf/html/gian/kaiji195.htm#05)
  * SJISからUTF-8に自動変換できない文字を辞書ファイルに随時登録していき、エラーが発生したら辞書ファイルを参照して、登録されている文字であれば変換する