### PR TITLE
衆議院の議案ページの文字コードをCP932として読み込み、UTF-8にエンコードする

### DIFF
--- a/app/lib/bill_scrapper.rb
+++ b/app/lib/bill_scrapper.rb
@@ -10,14 +10,16 @@ class BillScrapper
 
     private
       def latest_bill_page
-        @latest_bill_page ||= URI.open(BillUri::LATEST_BILLS_URI, "r:CP932").read
+        @latest_bill_page ||= read_as_cp932(BillUri::LATEST_BILLS_URI)
       end
 
       def old_bill_pages
         @old_bill_pages ||=
-          BillUri.old_session_urls(extract_session_numbers).map do
-            URI.open(_1, "r:CP932").read
-          end
+          BillUri.old_session_urls(extract_session_numbers).map{ read_as_cp932(_1) }
+      end
+
+      def read_as_cp932(uri)
+        URI.open(uri, "r:CP932").read
       end
 
       def extract_session_numbers

--- a/app/lib/bill_scrapper.rb
+++ b/app/lib/bill_scrapper.rb
@@ -15,7 +15,7 @@ class BillScrapper
 
       def old_bill_pages
         @old_bill_pages ||=
-          BillUri.old_session_urls(extract_session_numbers).map{ read_as_cp932(_1) }
+          BillUri.old_session_urls(extract_session_numbers).map { read_as_cp932(_1) }
       end
 
       def read_as_cp932(uri)

--- a/app/lib/bill_scrapper.rb
+++ b/app/lib/bill_scrapper.rb
@@ -10,13 +10,13 @@ class BillScrapper
 
     private
       def latest_bill_page
-        @latest_bill_page ||= URI.open(BillUri::LATEST_BILLS_URI).read
+        @latest_bill_page ||= URI.open(BillUri::LATEST_BILLS_URI, "r:CP932").read
       end
 
       def old_bill_pages
         @old_bill_pages ||=
           BillUri.old_session_urls(extract_session_numbers).map do
-            URI.open(_1).read
+            URI.open(_1, "r:CP932").read
           end
       end
 


### PR DESCRIPTION
ref: #9

### 概要
衆議院サイトのページをShift_JISとして読み込むと、UTF-8への変換時にエラーが発生する場合があるため、CP932として読み込むよう変更する。

### 背景
* PR #34 からの派生
* 具体的には、右記のリンク先の"Ⅸ"が変換できなかった →[第195回  「衆法の一覧」内の"Ⅸ"]
* Shift_JISには英数字が定義されていないため、UndefinedConversionErrorとなる。
* CP932はShift_JISを拡張したものであり、英数字も定義されている。

### 確認
Shift_JISとして読み込んだ場合
![bill_watcher_—_script___log_terminal_2020-04-16_140916_log_▸_irb_—_Solarized_Dark_ansi_—_80×24](https://user-images.githubusercontent.com/48672932/79417189-48496380-7fec-11ea-8ee4-bd2de1d549d7.png)

CP932として読み込んだ場合
![bill_watcher_—_script___log_terminal_2020-04-16_140916_log_▸_irb_—_Solarized_Dark_ansi_—_80×24](https://user-images.githubusercontent.com/48672932/79417240-66af5f00-7fec-11ea-95ff-8a154c39b32f.png)

### 参考
* [Shift_JISのダメ文字](https://sites.google.com/site/fudist/Home/grep/sjis-damemoji-jp)
* [本当は怖くないCP932](https://qiita.com/kasei-san/items/cfb993786153231e5413#cp932%E3%81%A3%E3%81%A6%E3%81%AA%E3%81%82%E3%81%AB)
* [JIS公式サイト検索](https://www.jisc.go.jp/app/jis/general/GnrJISSearch.html)
　JIS番号「X0208」で検索　→　検索結果の中の「X0208_006」にコード表あり 