### PR TITLE
過去の議案一覧から法案を抽出してDBに保存する

### DIFF
--- a/app/lib/bill_parser.rb
+++ b/app/lib/bill_parser.rb
@@ -8,10 +8,19 @@ class BillParser
   }
 
   class << self
-    def bills(page)
+    def latest_bills(page)
       PROPOSERS.flat_map do |key, proposer|
         rows = table_rows_without_header(page, proposer[:type])
-        build_bills(rows, proposer[:name], proposer[:id], latest_session_number(page))
+        build_bills(rows, proposer[:name], proposer[:id], current_session_number(page))
+      end
+    end
+
+    def old_bills(pages)
+      pages.flat_map do |page|
+        PROPOSERS.flat_map do |key, proposer|
+          rows = table_rows_without_header(page, proposer[:type])
+          build_bills(rows, proposer[:name], proposer[:id], current_session_number(page))
+        end
       end
     end
 
@@ -34,20 +43,20 @@ class BillParser
         rows.tap(&:shift)
       end
 
-      def build_bills(rows, proposer_name, proposer_id, latest_session_number)
+      def build_bills(rows, proposer_name, proposer_id, current_session_number)
         rows.map do |row|
           contents = extract_fields(row).map { content_in_field(_1) }
-          bill_info_from(contents, proposer_name, proposer_id, latest_session_number)
+          bill_info_from(contents, proposer_name, proposer_id, current_session_number)
         end
       end
 
-      def bill_info_from(contents, proposer_name, proposer_id, latest_session_number)
+      def bill_info_from(contents, proposer_name, proposer_id, current_session_number)
         {
           submitted_session_number: contents[0],
           bill_number:              contents[1],
           title:                    contents[2],
           proposer:                 proposer_name,
-          discussed_session_number: latest_session_number,
+          discussed_session_number: current_session_number,
           proposal:                 BillUri.proposal_url(contents[0], proposer_id, contents[1]),
           outline:                  BillUri.outline_url(contents[0], proposer_id, contents[1]),
           status:                   contents[3]
@@ -58,7 +67,7 @@ class BillParser
         row.scan(%r{<td.*?</td>}m)
       end
 
-      def latest_session_number(page)
+      def current_session_number(page)
         page.match(%r{<H2.*?(\d{1,3}).*?</H2>}).captures[0]
       end
 

--- a/app/lib/bill_parser.rb
+++ b/app/lib/bill_parser.rb
@@ -8,19 +8,10 @@ class BillParser
   }
 
   class << self
-    def latest_bills(page)
+    def bills(page)
       PROPOSERS.flat_map do |key, proposer|
         rows = table_rows_without_header(page, proposer[:type])
         build_bills(rows, proposer[:name], proposer[:id], current_session_number(page))
-      end
-    end
-
-    def old_bills(pages)
-      pages.flat_map do |page|
-        PROPOSERS.flat_map do |key, proposer|
-          rows = table_rows_without_header(page, proposer[:type])
-          build_bills(rows, proposer[:name], proposer[:id], current_session_number(page))
-        end
       end
     end
 

--- a/app/lib/bill_scrapper.rb
+++ b/app/lib/bill_scrapper.rb
@@ -5,11 +5,11 @@ require "open-uri"
 class BillScrapper
   class << self
     def latest_bills
-      BillParser.latest_bills(latest_bill_page)
+      BillParser.bills(latest_bill_page)
     end
 
     def old_bills
-      BillParser.old_bills(old_bill_pages)
+      old_bill_pages.flat_map { BillParser.bills(_1) }
     end
 
     private

--- a/app/lib/bill_scrapper.rb
+++ b/app/lib/bill_scrapper.rb
@@ -4,8 +4,12 @@ require "open-uri"
 
 class BillScrapper
   class << self
-    def latest_discussed_bills
-      BillParser.bills(latest_bill_page)
+    def latest_bills
+      BillParser.latest_bills(latest_bill_page)
+    end
+
+    def old_bills
+      BillParser.old_bills(old_bill_pages)
     end
 
     private
@@ -23,7 +27,7 @@ class BillScrapper
       end
 
       def extract_session_numbers
-        session_selectbox.scan(/第(\d{3})回/).flatten
+        session_selectbox.scan(/第(\d{3})回/).flatten.drop(1).reverse
       end
 
       def session_selectbox

--- a/app/lib/bill_scrapper.rb
+++ b/app/lib/bill_scrapper.rb
@@ -19,19 +19,23 @@ class BillScrapper
 
       def old_bill_pages
         @old_bill_pages ||=
-          BillUri.old_session_urls(extract_session_numbers).map { read_as_cp932(_1) }
+          BillUri.old_session_urls(extract_old_session_numbers).map { read_as_cp932(_1) }
       end
 
       def read_as_cp932(uri)
         URI.open(uri, "r:CP932").read
       end
 
-      def extract_session_numbers
-        session_selectbox.scan(/第(\d{3})回/).flatten.drop(1).reverse
+      def extract_old_session_numbers
+        session_numbers_excluding_latest(session_selectbox).reverse
       end
 
       def session_selectbox
         latest_bill_page.slice(%r{<SELECT NAME="kaiji".*?</SELECT>}m)
+      end
+
+      def session_numbers_excluding_latest(selectbox)
+        selectbox.scan(/第(\d{3})回/).flatten.drop(1)
       end
   end
 end

--- a/app/models/bill.rb
+++ b/app/models/bill.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 class Bill < ApplicationRecord
-  def self.save_latest_discussed_bills
-    BillScrapper.latest_discussed_bills.map { Bill.new(_1) }.each(&:save)
+  def self.save_latest_bills
+    BillScrapper.latest_bills.map { Bill.new(_1) }.each(&:save)
+  end
+
+  def self.save_old_bills
+    BillScrapper.old_bills.map { Bill.new(_1) }.each(&:save)
   end
 end

--- a/test/lib/bill_parser_test.rb
+++ b/test/lib/bill_parser_test.rb
@@ -25,7 +25,7 @@ class BillParserTest < ActiveSupport::TestCase
       outline: "http://www.shugiin.go.jp/internet/itdb_gian.nsf/html/gian/youkou/g20109053.htm",
       status: "衆議院で審議中"
     }
-    bills = BillParser.bills(PAGE)
+    bills = BillParser.latest_bills(PAGE)
     assert_equal first_bill, bills.first
     assert_equal last_bill, bills.last
   end

--- a/test/lib/bill_parser_test.rb
+++ b/test/lib/bill_parser_test.rb
@@ -25,7 +25,7 @@ class BillParserTest < ActiveSupport::TestCase
       outline: "http://www.shugiin.go.jp/internet/itdb_gian.nsf/html/gian/youkou/g20109053.htm",
       status: "衆議院で審議中"
     }
-    bills = BillParser.latest_bills(PAGE)
+    bills = BillParser.bills(PAGE)
     assert_equal first_bill, bills.first
     assert_equal last_bill, bills.last
   end


### PR DESCRIPTION
ref: #9 

### 概要
* 現在衆議院のサイトで公開されている全てのページから議案を取得し、DBに保存する。
* 古い会期のものから順に保存する。