### PR TITLE
DBの議案データを更新する処理を追加する

### DIFF
--- a/app/lib/bill_scrapper.rb
+++ b/app/lib/bill_scrapper.rb
@@ -5,17 +5,17 @@ require "open-uri"
 class BillScrapper
   class << self
     def all_bills
-      bill_pages.flat_map { BillParser.bills(_1) }
+      all_bill_pages.flat_map { BillParser.bills(_1) }
     end
 
     private
-      def latest_bill_page
-        @latest_bill_page ||= read_as_cp932(BillUri::LATEST_BILLS_URI)
+      def all_bill_pages
+        @bill_pages ||=
+          BillUri.session_urls(extract_old_session_numbers).map { read_as_cp932(_1) } << latest_bill_page
       end
 
-      def bill_pages
-        @bill_pages ||=
-          BillUri.session_urls(extract_all_session_numbers).map { read_as_cp932(_1) }
+      def latest_bill_page
+        @latest_bill_page ||= read_as_cp932(BillUri::LATEST_BILLS_URI)
       end
 
       def read_as_cp932(uri)
@@ -23,12 +23,16 @@ class BillScrapper
         URI.open(uri, "r:CP932").read
       end
 
-      def extract_all_session_numbers
-        session_selectbox.scan(/第(\d{3})回/).flatten.reverse
+      def extract_old_session_numbers
+        session_numbers_excluding_latest(session_selectbox).reverse
       end
 
       def session_selectbox
         latest_bill_page.slice(%r{<SELECT NAME="kaiji".*?</SELECT>}m)
+      end
+
+      def session_numbers_excluding_latest(selectbox)
+        selectbox.scan(/第(\d{3})回/).flatten.drop(1)
       end
   end
 end

--- a/app/lib/bill_scrapper.rb
+++ b/app/lib/bill_scrapper.rb
@@ -4,7 +4,7 @@ require "open-uri"
 
 class BillScrapper
   class << self
-    def all_bills
+    def all
       all_bill_pages.flat_map { BillParser.bills(_1) }
     end
 

--- a/app/lib/bill_scrapper.rb
+++ b/app/lib/bill_scrapper.rb
@@ -4,12 +4,8 @@ require "open-uri"
 
 class BillScrapper
   class << self
-    def latest_bills
-      BillParser.bills(latest_bill_page)
-    end
-
-    def old_bills
-      old_bill_pages.flat_map { BillParser.bills(_1) }
+    def all_bills
+      bill_pages.flat_map { BillParser.bills(_1) }
     end
 
     private
@@ -17,25 +13,21 @@ class BillScrapper
         @latest_bill_page ||= read_as_cp932(BillUri::LATEST_BILLS_URI)
       end
 
-      def old_bill_pages
-        @old_bill_pages ||=
-          BillUri.old_session_urls(extract_old_session_numbers).map { read_as_cp932(_1) }
+      def bill_pages
+        @bill_pages ||=
+          BillUri.session_urls(extract_all_session_numbers).map { read_as_cp932(_1) }
       end
 
       def read_as_cp932(uri)
         URI.open(uri, "r:CP932").read
       end
 
-      def extract_old_session_numbers
-        session_numbers_excluding_latest(session_selectbox).reverse
+      def extract_all_session_numbers
+        session_selectbox.scan(/第(\d{3})回/).flatten.reverse
       end
 
       def session_selectbox
         latest_bill_page.slice(%r{<SELECT NAME="kaiji".*?</SELECT>}m)
-      end
-
-      def session_numbers_excluding_latest(selectbox)
-        selectbox.scan(/第(\d{3})回/).flatten.drop(1)
       end
   end
 end

--- a/app/lib/bill_scrapper.rb
+++ b/app/lib/bill_scrapper.rb
@@ -19,6 +19,7 @@ class BillScrapper
       end
 
       def read_as_cp932(uri)
+        sleep 1
         URI.open(uri, "r:CP932").read
       end
 

--- a/app/lib/bill_uri.rb
+++ b/app/lib/bill_uri.rb
@@ -5,7 +5,7 @@ class BillUri
   BILLS_URI_PREFIX = "http://www.shugiin.go.jp/internet/itdb_gian.nsf/html/gian/"
 
   class << self
-    def old_session_urls(numbers)
+    def session_urls(numbers)
       numbers.map { BILLS_URI_PREFIX + "kaiji#{_1}.htm" }
     end
 

--- a/app/models/bill.rb
+++ b/app/models/bill.rb
@@ -1,11 +1,32 @@
 # frozen_string_literal: true
 
 class Bill < ApplicationRecord
-  def self.save_latest_bills
-    BillScrapper.latest_bills.map { Bill.new(_1) }.each(&:save)
-  end
+  class << self
+    def save_latest_bills
+      BillScrapper.latest_bills.map { Bill.new(_1) }.each(&:save)
+    end
 
-  def self.save_old_bills
-    BillScrapper.old_bills.map { Bill.new(_1) }.each(&:save)
+    def save_old_bills
+      BillScrapper.old_bills.map { Bill.new(_1) }.each(&:save)
+    end
+
+    def update_latest_bills
+      BillScrapper.latest_bills.each do |bill|
+        if existing_bill = existing(bill)
+          existing_bill.update(bill)
+        else
+          Bill.new(bill).save
+        end
+      end
+    end
+
+    private
+      def existing(bill)
+        Bill.find_by(
+          submitted_session_number: bill[:submitted_session_number],
+          bill_number:              bill[:bill_number],
+          discussed_session_number: bill[:discussed_session_number]
+        )
+      end
   end
 end

--- a/app/models/bill.rb
+++ b/app/models/bill.rb
@@ -4,21 +4,17 @@ class Bill < ApplicationRecord
   class << self
     def update_bills
       BillScrapper.all_bills.each do |bill|
-        if existing_bill = existing(bill)
-          existing_bill.update(bill)
-        else
-          Bill.new(bill).save
-        end
+        Bill.find_or_initialize_by(existing_check_hash(bill)).update(bill)
       end
     end
 
     private
-      def existing(bill)
-        Bill.find_by(
+      def existing_check_hash(bill)
+        {
           submitted_session_number: bill[:submitted_session_number],
           bill_number:              bill[:bill_number],
           discussed_session_number: bill[:discussed_session_number]
-        )
+        }
       end
   end
 end

--- a/app/models/bill.rb
+++ b/app/models/bill.rb
@@ -2,16 +2,8 @@
 
 class Bill < ApplicationRecord
   class << self
-    def save_latest_bills
-      BillScrapper.latest_bills.map { Bill.new(_1) }.each(&:save)
-    end
-
-    def save_old_bills
-      BillScrapper.old_bills.map { Bill.new(_1) }.each(&:save)
-    end
-
-    def update_latest_bills
-      BillScrapper.latest_bills.each do |bill|
+    def update_bills
+      BillScrapper.all_bills.each do |bill|
         if existing_bill = existing(bill)
           existing_bill.update(bill)
         else

--- a/app/models/bill.rb
+++ b/app/models/bill.rb
@@ -3,7 +3,7 @@
 class Bill < ApplicationRecord
   class << self
     def update_bills
-      BillScrapper.all_bills.each do |bill|
+      BillScrapper.all.each do |bill|
         Bill.find_or_initialize_by(existing_check_hash(bill)).update(bill)
       end
     end


### PR DESCRIPTION
ref: #11 

### 概要
* 衆議院サイトで公開されている最新の議案情報を取得し、DBのデータもそれに合わせて更新する。
* 会期番号と議案番号でDBのデータと照会し、すでに登録済みの議案であれば更新、未登録の議案であれば新規作成して保存する。
  * 衆議院サイトの内容が変化しているかどうかは考慮せず、都度一括で更新する。
* 今回追加するメソッドで新規作成までカバーできるため、新規議案作成と既存議案更新を一つのメソッドにまとめる。
* 併せて、「最新の議案ページ」と「過去の議案ページ」を分けて処理することも意味が薄いと思われるため、「全ての議案ページ」としてまとめて処理する。