### PR TITLE
wheneverにより1日1回DBのBillテーブルを更新する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem "bootsnap", ">= 1.4.2", require: false
 
 # not default
 gem "slim-rails", "~> 3.2"
+gem "whenever"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,7 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    chronic (0.10.2)
     concurrent-ruby (1.1.6)
     crass (1.0.6)
     erubi (1.9.0)
@@ -226,6 +227,8 @@ GEM
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.3.0)
@@ -256,6 +259,7 @@ DEPENDENCIES
   web-console (>= 3.3.0)
   webdrivers
   webpacker (~> 4.0)
+  whenever
 
 RUBY VERSION
    ruby 2.7.0p0

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -5,7 +5,7 @@ require "active_support/core_ext/time"
 set :output, "/Users/chibayuta/dev/myapps/bill_watcher/tmp/bill_update.log"
 set :job_template, nil
 set :environment, "development"
-ENV.each { |key, value| env(key, value) }
+env("PATH", ENV["PATH"])
 
 def jst(time)
   Time.zone = "Asia/Tokyo"

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,10 +1,17 @@
 # frozen_string_literal: true
 
+require "active_support/core_ext/time"
+
 set :output, "/Users/chibayuta/dev/myapps/bill_watcher/tmp/bill_update.log"
 set :job_template, nil
 set :environment, "development"
 ENV.each { |key, value| env(key, value) }
 
-every 1.day, at: "2:00 am" do
-  runner "Bill.update_bills"
+def jst(time)
+  Time.zone = "Asia/Tokyo"
+  Time.zone.parse(time).localtime($system_utc_offset)
+end
+
+every 1.day, at: jst("2:00 am") do
+  runner "Bill.update_all"
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+set :output, "/Users/chibayuta/dev/myapps/bill_watcher/tmp/bill_update.log"
+set :job_template, nil
+set :environment, "development"
+ENV.each { |key, value| env(key, value) }
+
+every 1.day, at: "2:00 am" do
+  runner "Bill.update_bills"
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -4,7 +4,8 @@ require "active_support/core_ext/time"
 
 set :output, "/Users/chibayuta/dev/myapps/bill_watcher/tmp/bill_update.log"
 set :job_template, nil
-set :environment, "development"
+rails_env = ENV["RAILS_ENV"] || "development"
+set :environment, rails_env
 env("PATH", ENV["PATH"])
 
 def jst(time)


### PR DESCRIPTION
ref: #11 

### 概要
* whenever gemを使い、 1日1回、Bill.update_billsメソッドを実行する
  * 本メソッドを実行すると、衆議院の公式サイトで現在公開されている全ての議案ページを参照し、法案の抽出とDBの一括更新が行われる
* 実行タイミングは午前2時とする

### whenever gem によって生成されたcron
```
PATH=/Users/chibayuta/.rbenv/versions/2.7.0/bin:/usr/local/Cellar/rbenv/1.1.2/libexec:/Users/chibayuta/.rbenv/shims:/Users/chibayuta/.rbenv/shims:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin

0 2 * * * cd /Users/chibayuta/dev/myapps/bill_watcher && bundle exec bin/rails runner -e development 'Bill.update_all' >> /Users/chibayuta/dev/myapps/bill_watcher/tmp/bill_update.log 2>&1
```