### PR TITLE
過去の議案一覧から法案を抽出してDBに保存する（つづき）

### DIFF
--- a/app/lib/bill_scrapper.rb
+++ b/app/lib/bill_scrapper.rb
@@ -11,7 +11,7 @@ class BillScrapper
     private
       def all_bill_pages
         @bill_pages ||=
-          BillUri.session_urls(extract_old_session_numbers).map { read_as_cp932(_1) } << latest_bill_page
+          [latest_bill_page, *BillUri.session_urls(session_numbers_excluding_latest).map { read_as_cp932(_1) }].reverse
       end
 
       def latest_bill_page
@@ -23,16 +23,12 @@ class BillScrapper
         URI.open(uri, "r:CP932").read
       end
 
-      def extract_old_session_numbers
-        session_numbers_excluding_latest(session_selectbox).reverse
+      def session_numbers_excluding_latest
+        session_selectbox.scan(/第(\d{3})回/).flatten.drop(1)
       end
 
       def session_selectbox
         latest_bill_page.slice(%r{<SELECT NAME="kaiji".*?</SELECT>}m)
-      end
-
-      def session_numbers_excluding_latest(selectbox)
-        selectbox.scan(/第(\d{3})回/).flatten.drop(1)
       end
   end
 end

--- a/app/lib/bill_scrapper.rb
+++ b/app/lib/bill_scrapper.rb
@@ -11,7 +11,7 @@ class BillScrapper
     private
       def all_bill_pages
         @bill_pages ||=
-          [latest_bill_page, *BillUri.session_urls(session_numbers_excluding_latest).map { read_as_cp932(_1) }].reverse
+          [latest_bill_page, *BillUri.session_urls(session_numbers_excluding_latest).map { read_as_cp932(_1) }]
       end
 
       def latest_bill_page

--- a/app/lib/bill_scrapper.rb
+++ b/app/lib/bill_scrapper.rb
@@ -24,6 +24,7 @@ class BillScrapper
       end
 
       def session_numbers_excluding_latest
+        # 最新の議案ページは@latest_bill_pageとして読み出し済みのため、ここでは除外する。
         session_selectbox.scan(/第(\d{3})回/).flatten.drop(1)
       end
 

--- a/app/lib/bill_scrapper.rb
+++ b/app/lib/bill_scrapper.rb
@@ -24,7 +24,8 @@ class BillScrapper
       end
 
       def session_numbers_excluding_latest
-        # 最新の議案ページは@latest_bill_pageとして読み出し済みのため、ここでは除外する。
+        # 最新の議案ページは、現在閲覧できる会期番号を取得するため、latest_bill_pageメソッドで最初に読み出している。
+        # 衆議院の公式サイトへのアクセス回数削減のため、ここでは最新会期の番号を除外する。
         session_selectbox.scan(/第(\d{3})回/).flatten.drop(1)
       end
 

--- a/app/models/bill.rb
+++ b/app/models/bill.rb
@@ -2,7 +2,7 @@
 
 class Bill < ApplicationRecord
   class << self
-    def update_bills
+    def update_all
       BillScrapper.all.each do |bill|
         Bill.find_or_initialize_by(existing_check_hash(bill)).update(bill)
       end


### PR DESCRIPTION
ref: #11 

### 概要
* 本来PR #38 の中で盛り込む内容だったが漏れてしまったので、再度PRを提出する
* updateメソッドをわかりやすくするため、変数の初期化タイミング、メソッド名を修正する
