### PR TITLE
ナビゲーションバーを追加

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -15,6 +15,7 @@
  */
 
 .logo {
+  font-size: 20px;
   font-weight: bold;
   color: rgba(255, 255, 255, 1);
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,11 @@
  *= require_tree .
  *= require_self
  */
+
+.logo {
+  font-weight: bold;
+  color: rgba(255, 255, 255, 1);
+}
+.title, .table {
+  margin-top: 20px
+}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -18,6 +18,9 @@
   font-weight: bold;
   color: rgba(255, 255, 255, 1);
 }
+.logo:hover {
+  color: rgba(255, 255, 255, 1);
+}
 .title, .table {
   margin-top: 20px
 }

--- a/app/assets/stylesheets/index.css
+++ b/app/assets/stylesheets/index.css
@@ -1,7 +1,3 @@
-.container {
-  padding-top: 20px;
-}
-
 .bill-table__head__title, .bill-table__body__title  {
   width: 60%;
 }

--- a/app/views/bills/index.html.slim
+++ b/app/views/bills/index.html.slim
@@ -1,7 +1,7 @@
 p#notice = notice
 
 .container
-  h.title.is-1
+  h1.title.is-1
     = t ".title"
 
 article

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -11,6 +11,7 @@ html
     header.hero.is-link
       nav.navbar
         .container
-          .navbar-brand.navbar-item
-            = link_to "審議法案ウォッチャー", bills_path, class: "logo"
+          = link_to bills_path do
+            .navbar-brand.navbar-item
+              p.logo = "審議法案ウォッチャー"
     = yield

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -11,8 +11,6 @@ html
     header.hero.is-primary
       nav.navbar
         .container
-          .navbar-brand
-            .navbar-item
-              p.logo 審議法案ウォッチャー
-          = link_to t("bills.index.title"), bills_path, class: "navbar-item"
+          .navbar-brand.navbar-item
+            = link_to "審議法案ウォッチャー", bills_path, class: "logo"
     = yield

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -8,4 +8,11 @@ html
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
   body
+    header.hero.is-primary
+      nav.navbar
+        .container
+          .navbar-brand
+            .navbar-item
+              p.logo 審議法案ウォッチャー
+          = link_to t("bills.index.title"), bills_path, class: "navbar-item"
     = yield

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -8,7 +8,7 @@ html
     = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
   body
-    header.hero.is-primary
+    header.hero.is-link
       nav.navbar
         .container
           .navbar-brand.navbar-item


### PR DESCRIPTION
ref: #16 

## 概要
* ページ上部にナビゲーションバーを追加する
* containerクラスを`padding-top: 20%`としていたが、ナビゲーションバーの上部が開きすぎるので、titleとtableにのみ適用するように修正
* 前回の見落としで、\<h1\>が\<h\>になっていたので修正

## before
![BillWatcher](https://user-images.githubusercontent.com/48672932/79944480-935cee00-84a6-11ea-835f-ba1c66f9a81e.png)

## after
![BillWatcher](https://user-images.githubusercontent.com/48672932/79944181-d66a9180-84a5-11ea-8fd0-43190e7f25de.png)
