### PR TITLE
コメントの見栄えを整える

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,7 +13,9 @@
  *= require_tree .
  *= require_self
  */
-
+article {
+  margin-bottom: 50px;
+}
 .logo {
   font-size: 20px;
   font-weight: bold;

--- a/app/assets/stylesheets/index.css
+++ b/app/assets/stylesheets/index.css
@@ -4,3 +4,6 @@
 .bill-table { 
   margin-top: 20px;
 }
+#notice {
+  font-weight: bold;
+}

--- a/app/assets/stylesheets/show.css
+++ b/app/assets/stylesheets/show.css
@@ -1,7 +1,10 @@
-.bill{
+.bill, .comments, .comment-form {
   margin-top: 30px
 }
 .bill tr td:nth-child(1) {
   width:140px;
+  font-weight: bold;
+}
+#notice {
   font-weight: bold;
 }

--- a/app/views/bills/index.html.slim
+++ b/app/views/bills/index.html.slim
@@ -1,4 +1,4 @@
-p#notice = notice
+p#notice.hero.is-success.has-text-centered = notice
 
 .container
   h1.title.is-1

--- a/app/views/bills/show.html.slim
+++ b/app/views/bills/show.html.slim
@@ -1,4 +1,4 @@
-p#notice = notice
+p#notice.hero.is-success.has-text-centered = notice
 
 article
   .container
@@ -32,9 +32,11 @@ article
 
     = link_to t(".back"), bills_path
 
-    h2.title.is-2 = t ".comment_title"
-    - if @bill.comments.present?
-      = render partial: "comments/comment", collection: @comments, as: :comment
-    - else
-      p.no-comment = t ".no_comment"
-    = render partial: "comments/form", locals: { bill: @bill, comment: @bill.comments.new }
+    .comments
+      h2.title.is-4 = t ".comment_title"
+      - if @bill.comments.present?
+        = render partial: "comments/comment", collection: @comments, as: :comment
+      - else
+        p.has-text-grey.no-comment = t ".no_comment"
+      .comment-form
+        = render partial: "comments/form", locals: { bill: @bill, comment: @bill.comments.new }

--- a/app/views/comments/_form.html.slim
+++ b/app/views/comments/_form.html.slim
@@ -6,7 +6,7 @@
         - comment.errors.full_messages.each do |message|
           li = message
   .field
-    = f.label I18n.t(".comments.new_comment")
-    = f.text_area :description
+    = f.label I18n.t(".comments.new_comment"), class: "label"
+    = f.text_area :description, class: "textarea", placeholder:  I18n.t(".comments.placeholder")
     
-  .actions = f.submit
+  .actions = f.submit value: I18n.t(".comments.submit"), class: "button is-link"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -24,6 +24,7 @@ ja:
   comments:
     new_comment: "新規コメント"
     submit: "投稿する"
+    placeholder: "コメントを記入してください"
     create:
       success: "コメントを投稿しました"
     update:


### PR DESCRIPTION
ref: #19 

## 概要
* ページ最下部の隙間がなく見辛いのでarticle全体にmargin-bottomを適用
* コメント作成成功時のフラッシュメッセージをみやすくするためバナーに変更
* コメントエリア上部の隙間は他のエリアと同様にmargin-topを適用
* コメントフォームをページ全体に対してと統一感のあるデザインに変更

## コメントなし
### before
![BillWatcher](https://user-images.githubusercontent.com/48672932/80165833-5feda100-8617-11ea-9782-8d836d258900.png)
### after
![BillWatcher](https://user-images.githubusercontent.com/48672932/80165954-ae02a480-8617-11ea-9cc3-75a6316e259b.png)

## コメント投稿時
### before
![BillWatcher](https://user-images.githubusercontent.com/48672932/80166195-57499a80-8618-11ea-9a22-6cf021ad5e6c.png)
### after
![BillWatcher](https://user-images.githubusercontent.com/48672932/80166011-d25e8100-8617-11ea-8f0f-c73188ef7bd6.png)

## ページ下部隙間
### before
![BillWatcher](https://user-images.githubusercontent.com/48672932/80166262-79dbb380-8618-11ea-8f35-2c64d24cdf5d.png)

### after
![BillWatcher](https://user-images.githubusercontent.com/48672932/80166132-28332900-8618-11ea-8176-891f435b076f.png)
