### PR TITLE
空のコメントが投稿できないようにする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem "bootsnap", ">= 1.4.2", require: false
 # not default
 gem "slim-rails", "~> 3.2"
 gem "whenever"
+gem "hurricane_trimar"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,7 @@ GEM
     ffi (1.12.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hurricane_trimar (0.1.0)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
@@ -240,6 +241,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)
+  hurricane_trimar
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
   puma (~> 4.1)

--- a/app/assets/stylesheets/show.css
+++ b/app/assets/stylesheets/show.css
@@ -5,6 +5,6 @@
   width:140px;
   font-weight: bold;
 }
-#notice {
+#notice, #alert {
   font-weight: bold;
 }

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -9,7 +9,7 @@ class CommentsController < ApplicationController
     if @comment.save
       redirect_to bill_path(@comment.bill), notice: t(".success")
     else
-      flash[:alert] = t(".empty") if @comment.description.trim.empty?
+      @comment.errors.full_messages.each { |message| flash[:alert] = message }
       redirect_to bill_path(@comment.bill)
     end
   end
@@ -18,7 +18,7 @@ class CommentsController < ApplicationController
     if @comment.update(comment_params)
       redirect_to bill_path(@comment.bill), notice: t(".success")
     else
-      flash[:alert] = t(".empty") if @comment.description.trim.empty?
+      @comment.errors.full_messages.each { |message| flash[:alert] = message }
       redirect_to bill_path(@comment.bill)
     end
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -9,7 +9,7 @@ class CommentsController < ApplicationController
     if @comment.save
       redirect_to bill_path(@comment.bill), notice: t(".success")
     else
-      @comment.errors.full_messages.each { |message| flash[:alert] = message }
+      flash[:alert] = @comment.errors.full_messages.join("<br>")
       redirect_to bill_path(@comment.bill)
     end
   end
@@ -18,7 +18,7 @@ class CommentsController < ApplicationController
     if @comment.update(comment_params)
       redirect_to bill_path(@comment.bill), notice: t(".success")
     else
-      @comment.errors.full_messages.each { |message| flash[:alert] = message }
+      flash[:alert] = @comment.errors.full_messages.join("<br>")
       redirect_to bill_path(@comment.bill)
     end
   end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -9,7 +9,8 @@ class CommentsController < ApplicationController
     if @comment.save
       redirect_to bill_path(@comment.bill), notice: t(".success")
     else
-      render bill_path(@comment.bill)
+      flash[:alert] = t(".empty") if @comment.description.trim.empty?
+      redirect_to bill_path(@comment.bill)
     end
   end
 
@@ -17,7 +18,8 @@ class CommentsController < ApplicationController
     if @comment.update(comment_params)
       redirect_to bill_path(@comment.bill), notice: t(".success")
     else
-      render bill_path(@comment.bill)
+      flash[:alert] = t(".empty") if @comment.description.trim.empty?
+      redirect_to bill_path(@comment.bill)
     end
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,4 +2,5 @@
 
 class Comment < ApplicationRecord
   belongs_to :bill
+  validates :description, presence: true
 end

--- a/app/views/bills/show.html.slim
+++ b/app/views/bills/show.html.slim
@@ -1,4 +1,4 @@
-p#alert.hero.is-danger.has-text-centered = alert
+p#alert.hero.is-danger.has-text-centered == alert
 p#notice.hero.is-success.has-text-centered = notice
 
 article

--- a/app/views/bills/show.html.slim
+++ b/app/views/bills/show.html.slim
@@ -1,3 +1,4 @@
+p#alert.hero.is-danger.has-text-centered = alert
 p#notice.hero.is-success.has-text-centered = notice
 
 article

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -25,6 +25,7 @@ ja:
     new_comment: "新規コメント"
     submit: "投稿する"
     placeholder: "コメントを記入してください"
+    empty: "空のコメントは投稿できません"
     create:
       success: "コメントを投稿しました"
     update:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,18 @@
 ja:
+  activerecord:
+    models:
+      bill: 法案
+      comment: コメント
+    attributes:
+      bill:
+        title: "法案一覧"
+        submitted_session: "提出会期"
+        bill_number: "議案番号"
+        bill_title: "法案名"
+        proposer: "提案元"
+        status: "審議状況"
+      comment:
+        description: コメント文
   bills:
     index:
       title: "法案一覧"
@@ -25,7 +39,6 @@ ja:
     new_comment: "新規コメント"
     submit: "投稿する"
     placeholder: "コメントを記入してください"
-    empty: "空のコメントは投稿できません"
     create:
       success: "コメントを投稿しました"
     update:


### PR DESCRIPTION
ref: #19 

## 概要
* commentモデルのdescriptionに、空の内容をはじくバリデーションを追加する
* 空文字、もしくは空白文字(全角スペース含む)のみのコメントを投稿した場合には画面上部にフラッシュメッセージを表示する
* commentsコントローラ内で、コメントが保存できなかった時にrenderメソッドを使用していたが、実際保存できなかったとき既存のコメントが表示されなくなるので、redirect_toに変更

## 空のコメントを投稿したときの画面
![BillWatcher](https://user-images.githubusercontent.com/48672932/80187266-4c0f6280-864a-11ea-88b2-be538df56244.png)
usercontent.com/48672932/80176957-26c42980-8635-11ea-86d2-ad9651dc34a6.png)

## 参考
https://api.rubyonrails.org/classes/ActiveModel/Errors.html
https://qiita.com/Ushinji/items/242bfba84df7a5a67d5b
https://qiita.com/iwamot/items/74c2bd9ebd3ac6458837