### PR TITLE
コメント機能のテスト追加

### DIFF
--- a/test/controllers/bills_controller_test.rb
+++ b/test/controllers/bills_controller_test.rb
@@ -9,8 +9,7 @@ class BillsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "showアクションを実行できる" do
-    bill = bills(:one)
-    get bill_url(bill)
+    get bill_url(bills(:one))
     assert_response :success
   end
 end

--- a/test/controllers/bills_controller_test.rb
+++ b/test/controllers/bills_controller_test.rb
@@ -3,17 +3,14 @@
 require "test_helper"
 
 class BillsControllerTest < ActionDispatch::IntegrationTest
-  setup do
-    @bill = bills(:one)
-  end
-
   test "indexアクションを実行できる" do
     get bills_url
     assert_response :success
   end
 
   test "showアクションを実行できる" do
-    get bill_url(@bill)
+    bill = bills(:one)
+    get bill_url(bill)
     assert_response :success
   end
 end

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -3,27 +3,27 @@
 require "test_helper"
 
 class CommentsControllerTest < ActionDispatch::IntegrationTest
-  setup do
-    @comment = comments(:one)
-    @bill = bills(:one)
-  end
-
   test "createアクションを実行できる" do
+    bill = bills(:one)
     assert_difference "Comment.count" do
-      post bill_comments_url(@bill), params: { comment: { description: "test" } }
+      post bill_comments_url(bill), params: { comment: { description: "test" } }
     end
-    assert_redirected_to @bill
+    assert_redirected_to bill
   end
 
   test "updateアクションを実行できる" do
-    put bill_comment_url(@bill, @comment), params: { comment: { description: "test" } }
-    assert_redirected_to @bill
+    comment = comments(:one)
+    bill = bills(:one)
+    put bill_comment_url(bill, comment), params: { comment: { description: "test" } }
+    assert_redirected_to bill
   end
 
   test "destroyアクションを実行できる" do
+    comment = comments(:one)
+    bill = bills(:one)
     assert_difference "Comment.count", -1 do
-      delete bill_comment_url(@bill, @comment)
+      delete bill_comment_url(bill, comment)
     end
-    assert_redirected_to @bill
+    assert_redirected_to bill
   end
 end

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 class CommentsControllerTest < ActionDispatch::IntegrationTest
   test "コメントの作成に成功した場合、法案詳細ページにリダイレクトされる" do
     bill = bills(:one)
-    assert_difference "bill.comments.count" do
+    assert_difference -> { bill.comments.count } do
       post bill_comments_url(bill), params: { comment: { description: "test" } }
     end
     assert_redirected_to bill_url(bill)
@@ -13,7 +13,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
 
   test "コメントの作成に失敗した（空のコメントを投稿した場合）場合、法案詳細ページにリダイレクトされる" do
     bill = bills(:one)
-    assert_no_difference "bill.comments.count" do
+    assert_no_difference -> { bill.comments.count } do
       post bill_comments_url(bill), params: { comment: { description: "" } }
     end
     assert_redirected_to bill_url(bill)
@@ -22,7 +22,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
   test "コメントの更新に成功した場合、法案詳細ページにリダイレクトされる" do
     comment = comments(:one)
     bill = bills(:one)
-    assert_changes "Comment.find(comment.id).description" do
+    assert_changes -> { Comment.find(comment.id).description } do
       put bill_comment_url(bill, comment), params: { comment: { description: "test" } }
     end
     assert_redirected_to bill_url(bill)
@@ -31,7 +31,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
   test "コメントの更新に失敗した（空のコメントを投稿した場合）場合、法案詳細ページにリダイレクトされる" do
     comment = comments(:one)
     bill = bills(:one)
-    assert_no_changes "Comment.find(comment.id).description" do
+    assert_no_changes -> { Comment.find(comment.id).description } do
       put bill_comment_url(bill, comment), params: { comment: { description: "" } }
     end
     assert_redirected_to bill_url(bill)
@@ -39,7 +39,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
 
   test "コメントの削除に成功した場合、法案詳細ページにリダイレクトされる" do
     bill = bills(:one)
-    assert_difference "bill.comments.count", -1 do
+    assert_difference -> { bill.comments.count }, -1 do
       delete bill_comment_url(bill, comments(:one))
     end
     assert_redirected_to bill_url(bill)

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CommentsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @comment = comments(:one)
+    @bill = bills(:one)
+  end
+
+  test "createアクションを実行できる" do
+    assert_difference "Comment.count" do
+      post bill_comments_url(@bill), params: { comment: { description: "test" } }
+    end
+    assert_redirected_to @bill
+  end
+
+  test "updateアクションを実行できる" do
+    put bill_comment_url(@bill, @comment), params: { comment: { description: "test" } }
+    assert_redirected_to @bill
+  end
+
+  test "destroyアクションを実行できる" do
+    assert_difference "Comment.count", -1 do
+      delete bill_comment_url(@bill, @comment)
+    end
+    assert_redirected_to @bill
+  end
+end

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -11,10 +11,25 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to bill
   end
 
+  test "コメントの作成に失敗した（空のコメントを投稿した場合）場合、法案詳細ページにリダイレクトされる" do
+    bill = bills(:one)
+    assert_no_difference "Comment.count" do
+      post bill_comments_url(bill), params: { comment: { description: "" } }
+    end
+    assert_redirected_to bill
+  end
+
   test "コメントの更新に成功した場合、法案詳細ページにリダイレクトされる" do
     comment = comments(:one)
     bill = bills(:one)
     put bill_comment_url(bill, comment), params: { comment: { description: "test" } }
+    assert_redirected_to bill
+  end
+
+  test "コメントの更新に失敗した（空のコメントを投稿した場合）場合、法案詳細ページにリダイレクトされる" do
+    comment = comments(:one)
+    bill = bills(:one)
+    put bill_comment_url(bill, comment), params: { comment: { description: "" } }
     assert_redirected_to bill
   end
 

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 
 class CommentsControllerTest < ActionDispatch::IntegrationTest
-  test "createアクションを実行できる" do
+  test "コメントの作成に成功した場合、法案詳細ページにリダイレクトされる" do
     bill = bills(:one)
     assert_difference "Comment.count" do
       post bill_comments_url(bill), params: { comment: { description: "test" } }
@@ -11,14 +11,14 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to bill
   end
 
-  test "updateアクションを実行できる" do
+  test "コメントの更新に成功した場合、法案詳細ページにリダイレクトされる" do
     comment = comments(:one)
     bill = bills(:one)
     put bill_comment_url(bill, comment), params: { comment: { description: "test" } }
     assert_redirected_to bill
   end
 
-  test "destroyアクションを実行できる" do
+  test "コメントの削除に成功した場合、法案詳細ページにリダイレクトされる" do
     comment = comments(:one)
     bill = bills(:one)
     assert_difference "Comment.count", -1 do

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -22,14 +22,18 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
   test "コメントの更新に成功した場合、法案詳細ページにリダイレクトされる" do
     comment = comments(:one)
     bill = bills(:one)
-    put bill_comment_url(bill, comment), params: { comment: { description: "test" } }
+    assert_changes "Comment.find(comment.id).description" do
+      put bill_comment_url(bill, comment), params: { comment: { description: "test" } }
+    end
     assert_redirected_to bill_url(bill)
   end
 
   test "コメントの更新に失敗した（空のコメントを投稿した場合）場合、法案詳細ページにリダイレクトされる" do
     comment = comments(:one)
     bill = bills(:one)
-    put bill_comment_url(bill, comment), params: { comment: { description: "" } }
+    assert_no_changes "Comment.find(comment.id).description" do
+      put bill_comment_url(bill, comment), params: { comment: { description: "" } }
+    end
     assert_redirected_to bill_url(bill)
   end
 

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 class CommentsControllerTest < ActionDispatch::IntegrationTest
   test "コメントの作成に成功した場合、法案詳細ページにリダイレクトされる" do
     bill = bills(:one)
-    assert_difference "Comment.count" do
+    assert_difference "bill.comments.count" do
       post bill_comments_url(bill), params: { comment: { description: "test" } }
     end
     assert_redirected_to bill_url(bill)
@@ -13,7 +13,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
 
   test "コメントの作成に失敗した（空のコメントを投稿した場合）場合、法案詳細ページにリダイレクトされる" do
     bill = bills(:one)
-    assert_no_difference "Comment.count" do
+    assert_no_difference "bill.comments.count" do
       post bill_comments_url(bill), params: { comment: { description: "" } }
     end
     assert_redirected_to bill_url(bill)
@@ -36,7 +36,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
   test "コメントの削除に成功した場合、法案詳細ページにリダイレクトされる" do
     comment = comments(:one)
     bill = bills(:one)
-    assert_difference "Comment.count", -1 do
+    assert_difference "bill.comments.count", -1 do
       delete bill_comment_url(bill, comment)
     end
     assert_redirected_to bill_url(bill)

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -8,7 +8,7 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_difference "Comment.count" do
       post bill_comments_url(bill), params: { comment: { description: "test" } }
     end
-    assert_redirected_to bill
+    assert_redirected_to bill_url(bill)
   end
 
   test "コメントの作成に失敗した（空のコメントを投稿した場合）場合、法案詳細ページにリダイレクトされる" do
@@ -16,21 +16,21 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_no_difference "Comment.count" do
       post bill_comments_url(bill), params: { comment: { description: "" } }
     end
-    assert_redirected_to bill
+    assert_redirected_to bill_url(bill)
   end
 
   test "コメントの更新に成功した場合、法案詳細ページにリダイレクトされる" do
     comment = comments(:one)
     bill = bills(:one)
     put bill_comment_url(bill, comment), params: { comment: { description: "test" } }
-    assert_redirected_to bill
+    assert_redirected_to bill_url(bill)
   end
 
   test "コメントの更新に失敗した（空のコメントを投稿した場合）場合、法案詳細ページにリダイレクトされる" do
     comment = comments(:one)
     bill = bills(:one)
     put bill_comment_url(bill, comment), params: { comment: { description: "" } }
-    assert_redirected_to bill
+    assert_redirected_to bill_url(bill)
   end
 
   test "コメントの削除に成功した場合、法案詳細ページにリダイレクトされる" do
@@ -39,6 +39,6 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_difference "Comment.count", -1 do
       delete bill_comment_url(bill, comment)
     end
-    assert_redirected_to bill
+    assert_redirected_to bill_url(bill)
   end
 end

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -38,10 +38,9 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "コメントの削除に成功した場合、法案詳細ページにリダイレクトされる" do
-    comment = comments(:one)
     bill = bills(:one)
     assert_difference "bill.comments.count", -1 do
-      delete bill_comment_url(bill, comment)
+      delete bill_comment_url(bill, comments(:one))
     end
     assert_redirected_to bill_url(bill)
   end

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -1,9 +1,9 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  bill_id: 1
-  description: MyText
+  bill: one
+  description: 法案oneへのコメント
 
 two:
-  bill_id: 1
+  bill: one
   description: MyText

--- a/test/system/bills_test.rb
+++ b/test/system/bills_test.rb
@@ -11,4 +11,16 @@ class BillsTest < ApplicationSystemTestCase
     visit bills_url
     assert_selector "h1", text: I18n.t("bills.index.title")
   end
+
+  test "個別の法案ページでコメントが表示される" do
+    visit bill_path(@bill)
+    assert_text "法案oneへのコメント"
+  end
+
+  test "個別の法案ページでコメントを追加できる" do
+    visit bill_path(@bill)
+    fill_in "comment[description]", with: "新しいコメント"
+    click_button "commit"
+    assert_text "新しいコメント"
+  end
 end

--- a/test/system/bills_test.rb
+++ b/test/system/bills_test.rb
@@ -17,8 +17,7 @@ class BillsTest < ApplicationSystemTestCase
   end
 
   test "個別の法案ページでコメントを追加できる" do
-    bill = bills(:one)
-    visit bill_url(bill)
+    visit bill_url(bills(:one))
     fill_in "comment[description]", with: "新しいコメント"
     click_button "commit"
     assert_text "新しいコメント"

--- a/test/system/bills_test.rb
+++ b/test/system/bills_test.rb
@@ -8,10 +8,12 @@ class BillsTest < ApplicationSystemTestCase
     assert_selector "h1", text: I18n.t("bills.index.title")
   end
 
-  test "個別の法案ページでコメントが表示される" do
+  test "個別の法案ページでその法案に紐づくコメントが全て表示される" do
     bill = bills(:one)
     visit bill_url(bill)
     assert_text "法案oneへのコメント"
+    displayed_comments = all(:css, ".comment")
+    assert_equal bill.comments.count, displayed_comments.count
   end
 
   test "個別の法案ページでコメントを追加できる" do

--- a/test/system/bills_test.rb
+++ b/test/system/bills_test.rb
@@ -3,22 +3,20 @@
 require "application_system_test_case"
 
 class BillsTest < ApplicationSystemTestCase
-  setup do
-    @bill = bills(:one)
-  end
-
   test "法案一覧ページを表示できる" do
     visit bills_url
     assert_selector "h1", text: I18n.t("bills.index.title")
   end
 
   test "個別の法案ページでコメントが表示される" do
-    visit bill_path(@bill)
+    bill = bills(:one)
+    visit bill_path(bill)
     assert_text "法案oneへのコメント"
   end
 
   test "個別の法案ページでコメントを追加できる" do
-    visit bill_path(@bill)
+    bill = bills(:one)
+    visit bill_path(bill)
     fill_in "comment[description]", with: "新しいコメント"
     click_button "commit"
     assert_text "新しいコメント"

--- a/test/system/bills_test.rb
+++ b/test/system/bills_test.rb
@@ -10,13 +10,13 @@ class BillsTest < ApplicationSystemTestCase
 
   test "個別の法案ページでコメントが表示される" do
     bill = bills(:one)
-    visit bill_path(bill)
+    visit bill_url(bill)
     assert_text "法案oneへのコメント"
   end
 
   test "個別の法案ページでコメントを追加できる" do
     bill = bills(:one)
-    visit bill_path(bill)
+    visit bill_url(bill)
     fill_in "comment[description]", with: "新しいコメント"
     click_button "commit"
     assert_text "新しいコメント"


### PR DESCRIPTION
ref: #19 

## 概要
* コメント機能のテストを追加する
  * controllerテストとして、create, update, deleteを確認
  * systemテストとして、個別の法案ページでコメントを追加できることを確認
