### PR TITLE
法案一覧ページにページネーションを導入する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem "bootsnap", ">= 1.4.2", require: false
 gem "slim-rails", "~> 3.2"
 gem "whenever"
 gem "hurricane_trimar"
+gem "kaminari"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,18 @@ GEM
     jaro_winkler (1.5.4)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
+    kaminari (1.2.0)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.0)
+      kaminari-activerecord (= 1.2.0)
+      kaminari-core (= 1.2.0)
+    kaminari-actionview (1.2.0)
+      actionview
+      kaminari-core (= 1.2.0)
+    kaminari-activerecord (1.2.0)
+      activerecord
+      kaminari-core (= 1.2.0)
+    kaminari-core (1.2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -243,6 +255,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   hurricane_trimar
   jbuilder (~> 2.7)
+  kaminari
   listen (>= 3.0.5, < 3.2)
   puma (~> 4.1)
   rails (~> 6.0.2, >= 6.0.2.2)

--- a/app/controllers/bills_controller.rb
+++ b/app/controllers/bills_controller.rb
@@ -4,7 +4,7 @@ class BillsController < ApplicationController
   before_action :set_bill, only: [:show]
 
   def index
-    @bills = Bill.all
+    @bills = Bill.page(params[:page])
   end
 
   def show

--- a/app/views/bills/index.html.slim
+++ b/app/views/bills/index.html.slim
@@ -6,6 +6,7 @@ p#notice.hero.is-success.has-text-centered = notice
 
 article
   .container
+    = paginate @bills
     table.table.is-hoverable.bill-table
       thead.bill-table__head
         tr
@@ -29,3 +30,4 @@ article
               = link_to bill.title, bill
             td.bill-table__body__status
               = bill.status
+    = paginate @bills

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -45,3 +45,19 @@ ja:
       success: "コメントを修正しました"
     destroy:
       success: "コメントを削除しました"
+  views:
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      previous: "&lsaquo; 前"
+      next: "次 &rsaquo;"
+      truncate: "&hellip;"
+  helpers:
+    page_entries_info:
+      one_page:
+        display_entries:
+          zero: "%{entry_name}はありません"
+          one: "<b>1件</b>の%{entry_name}を表示中"
+          other: "<b>全%{count}件</b>の%{entry_name}を表示中"
+      more_pages:
+        display_entries: "<b>全%{total}件</b>中<b>%{first}&nbsp;-&nbsp;%{last}件目</b>の%{entry_name}を表示中"


### PR DESCRIPTION
ref: #54 

## 概要
* 法案一覧にページネーションを表示する
* ページの上部と下部にそれぞれ表示する
* 日本語で表示する
* 本PRでは導入と日本語化のみ実施し、デザインは別のPRにて対応する

## 作業後の画面
![BillWatcher](https://user-images.githubusercontent.com/48672932/80440573-08677200-8944-11ea-9315-d0899f2b647a.png)
![BillWatcher](https://user-images.githubusercontent.com/48672932/80440598-17e6bb00-8944-11ea-932e-e7d1f5a8f801.png)

