### PR TITLE
 ransackにより法案一覧ページに絞り込み検索機能を追加する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem "slim-rails", "~> 3.2"
 gem "whenever"
 gem "hurricane_trimar"
 gem "kaminari"
+gem "ransack"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,8 @@ GEM
     parallel (1.19.1)
     parser (2.7.0.5)
       ast (~> 2.4.0)
+    polyamorous (2.3.2)
+      activerecord (>= 5.2.1)
     public_suffix (4.0.3)
     puma (4.3.3)
       nio4r (~> 2.0)
@@ -157,6 +159,11 @@ GEM
       thor (>= 0.20.3, < 2.0)
     rainbow (3.0.0)
     rake (13.0.1)
+    ransack (2.3.2)
+      activerecord (>= 5.2.1)
+      activesupport (>= 5.2.1)
+      i18n
+      polyamorous (= 2.3.2)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -259,6 +266,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   puma (~> 4.1)
   rails (~> 6.0.2, >= 6.0.2.2)
+  ransack
   rubocop
   rubocop-performance
   rubocop-rails

--- a/app/controllers/bills_controller.rb
+++ b/app/controllers/bills_controller.rb
@@ -4,7 +4,8 @@ class BillsController < ApplicationController
   before_action :set_bill, only: [:show]
 
   def index
-    @bills = Bill.order(:id).page(params[:page])
+    @q = Bill.ransack(params[:q])
+    @bills = @q.result.order(:id).page(params[:page])
   end
 
   def show

--- a/app/views/bills/index.html.slim
+++ b/app/views/bills/index.html.slim
@@ -4,6 +4,29 @@ p#notice.hero.is-success.has-text-centered = notice
   h1.title.is-1
     = t ".title"
 
+.container
+  p = t ".refine_search"
+  = search_form_for @q, class: "refine_search_form" do |f|
+    = f.label :title
+    = f.text_field :title_cont
+    br
+    = f.label :submitted_session_number
+    = f.number_field :submitted_session_number_gteq
+    span = t ".from"
+    = f.number_field :submitted_session_number_lteq
+    span = t ".to"
+    br
+    = f.label :discussed_session_number
+    = f.number_field :discussed_session_number_gteq
+    span = t ".from"
+    = f.number_field :discussed_session_number_lteq
+    span = t ".to"
+    br
+    = f.label :status
+    = f.text_field :status_cont
+    br
+    = f.submit t(".refine"), class: "button"
+
 article
   .container
     = paginate @bills, window: 2, outer_window: 1
@@ -12,6 +35,8 @@ article
         tr
           th.bill-table__head__submitted-session
             = t ".submitted_session"
+          th.bill-table__head__discussed-session
+            = t ".discussed_session"
           th.bill-table__head__bill-number
             = t ".bill_number"
           th.bill-table__head__title
@@ -22,8 +47,10 @@ article
       tbody.bill-table__body
         - @bills.each do |bill|
           tr
-            td.bill-table__body__session-number
+            td.bill-table__body__submitted-session-number
               = bill.submitted_session_number
+            td.bill-table__body__discussed-session-number
+              = bill.discussed_session_number
             td.bill-table__body__bill-number
               = bill.bill_number
             td.bill-table__body__title

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,18 +5,25 @@ ja:
       comment: コメント
     attributes:
       bill:
-        title: "法案一覧"
-        submitted_session: "提出会期"
+        title: "法案名"
+        submitted_session_number: "提出会期"
+        discussed_session_number: "審議会期"
         bill_number: "議案番号"
-        bill_title: "法案名"
         proposer: "提案元"
         status: "審議状況"
+        proposal: "提出時法案"
+        outline: "要綱"
       comment:
         description: コメント文
   bills:
     index:
       title: "法案一覧"
+      refine_search: "絞り込み検索"
+      from: "回から"
+      to: "回まで"
+      refine: "絞り込む"
       submitted_session: "提出会期"
+      discussed_session: "審議会期"
       bill_number: "議案番号"
       bill_title: "法案名"
       proposer: "提案元"


### PR DESCRIPTION
ref: #55 

## 概要
* [ransack gem](https://github.com/activerecord-hackery/ransack)を利用する
* 法案名、提出会期、審議会期、審議状況で検索できるようにする
  * これに伴い、法案一覧ページに審議会期の欄を追加する
* 本PRでは機能の導入と日本語化のみ行い、デザインは別PRで対応する
  * localeファイルの内容に一部誤りが見つかったため、併せて修正する 

## 作業後の画面
<img width="1443" alt="BillWatcher" src="https://user-images.githubusercontent.com/48672932/80677026-098ad180-8af3-11ea-9304-8cdf091b37dd.png">

##  参考
https://qiita.com/nojinoji/items/e1b174220da8c81a1756