### PR TITLE
絞り込み検索フォームを見やすくする

### DIFF
--- a/app/assets/stylesheets/index.css
+++ b/app/assets/stylesheets/index.css
@@ -1,4 +1,4 @@
-.bill-table__head__title, .bill-table__body__title  {
+.bill-table__head__title, .bill-table__body__title {
   width: 60%;
 }
 .bill-table {
@@ -6,4 +6,15 @@
 }
 #notice {
   font-weight: bold;
+}
+.refine_search {
+  padding: 10px;
+  margin-bottom: 30px;
+  width: 650px
+}
+.refine_search__summary {
+  font-weight: bold;
+}
+.refine_search__form input {
+  font-size: 16px;
 }

--- a/app/views/bills/index.html.slim
+++ b/app/views/bills/index.html.slim
@@ -5,27 +5,35 @@ p#notice.hero.is-success.has-text-centered = notice
     = t ".title"
 
 .container
-  p = t ".refine_search"
-  = search_form_for @q, class: "refine_search_form" do |f|
-    = f.label :title
-    = f.text_field :title_cont
-    br
-    = f.label :submitted_session_number
-    = f.number_field :submitted_session_number_gteq
-    span = t ".from"
-    = f.number_field :submitted_session_number_lteq
-    span = t ".to"
-    br
-    = f.label :discussed_session_number
-    = f.number_field :discussed_session_number_gteq
-    span = t ".from"
-    = f.number_field :discussed_session_number_lteq
-    span = t ".to"
-    br
-    = f.label :status
-    = f.text_field :status_cont
-    br
-    = f.submit t(".refine"), class: "button"
+  details.refine_search.panel
+    summary.refine_search__summary = t ".refine_search"
+    = search_form_for @q, class: "refine_search__form" do |f|
+      table.table
+        tbody
+          tr
+            td = t(".bill_title") + ": "
+            td = f.text_field :title_cont
+            td
+          tr
+            td = t(".submitted_session") + ": "
+            td
+              = f.number_field :submitted_session_number_gteq
+              span = t ".from"
+            td
+              = f.number_field :submitted_session_number_lteq
+              span = t ".to"
+          tr
+            td = t(".discussed_session") + ": "
+            td
+              = f.number_field :discussed_session_number_gteq
+              span = t ".from"
+            td
+              = f.number_field :submitted_session_number_lteq
+              span = t ".to"
+          tr
+            td = t(".status") + ": "
+            td = f.text_field :status_cont
+      = f.submit t(".refine"), class: "button is-light"
 
 article
   .container


### PR DESCRIPTION
ref: #55

## 概要
* 絞り込み検索のフォームを整列する
* bulmaのデザインを適用する
* detailsタグで囲み、必要な時だけ表示できるようにする

## 作業後の画面
before
<img width="1621" alt="BillWatcher" src="https://user-images.githubusercontent.com/48672932/80689136-cf77fa80-8b07-11ea-8df6-e9a3e93be689.png">

after
<img width="1621" alt="BillWatcher" src="https://user-images.githubusercontent.com/48672932/80689014-abb4b480-8b07-11ea-9f4d-10001adc2971.png">
