### PR TITLE
node-forgeのバージョンアップ(セキュリティアラートの対応)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "@rails/webpacker": "^5.1.1",
     "bulma": "^0.8.2",
     "serialize-javascript": "^4.0.0",
-    "turbolinks": "^5.2.0"
+    "turbolinks": "^5.2.0",
+    "node-forge": ">=0.10.0"
   },
   "version": "0.1.0",
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4704,6 +4704,11 @@ node-forge@0.9.0:
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.9.0.tgz#d624050edbb44874adca12bb9a52ec63cb782579"
   integrity sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==
 
+node-forge@>=0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
+  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
+
 node-gyp@^3.8.0:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.8.0.tgz#540304261c330e80d0d5edce253a68cb3964218c"


### PR DESCRIPTION
↓のアラートへの対応
![スクリーンショット 2020-10-13 23 18 32](https://user-images.githubusercontent.com/48672932/95872992-6c72db00-0daa-11eb-8ed6-64bfbf541a64.png)
