### PR TITLE
パスワードをわすれましたか？のリンクを表示せず、ページの中身もコメントアウトする

### DIFF
--- a/app/views/devise/passwords/new.html.slim
+++ b/app/views/devise/passwords/new.html.slim
@@ -1,11 +1,13 @@
-h2
-  = t(".forgot_your_password")
-= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
-  = render "devise/shared/error_messages", resource: resource
-  .field
-    = f.label :email
-    br
-    = f.email_field :email, autofocus: true, autocomplete: "email"
-  .actions
-    = f.submit t(".send_me_reset_password_instructions")
-= render "devise/shared/links"
+/ h2
+/   = t(".forgot_your_password")
+/ = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
+/   = render "devise/shared/error_messages", resource: resource
+/   .field
+/     = f.label :email
+/     br
+/     = f.email_field :email, autofocus: true, autocomplete: "email"
+/   .actions
+/     = f.submit t(".send_me_reset_password_instructions")
+/ = render "devise/shared/links"
+
+p 未実装の機能です

--- a/app/views/devise/shared/_links.html.slim
+++ b/app/views/devise/shared/_links.html.slim
@@ -1,5 +1,5 @@
 - if controller_name != 'sessions'
   = link_to t(".sign_in"), new_session_path(resource_name)
   br
-- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
-  = link_to t(".forgot_your_password"), new_password_path(resource_name)
+/ - if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations'
+/   = link_to t(".forgot_your_password"), new_password_path(resource_name)


### PR DESCRIPTION
現在はパスワード再設定のメールを送る機能がないのでとりあえず表示しない