### PR TITLE
Revert "議案ページの要綱リンクを本文情報リンクに変更"

### DIFF
--- a/app/controllers/bills_controller.rb
+++ b/app/controllers/bills_controller.rb
@@ -25,8 +25,8 @@ class BillsController < ApplicationController
         :proposer,
         :session_number,
         :bill_number,
-        :honbun,
         :proposal,
+        :outline,
         :status
       )
     end

--- a/app/lib/bill_parser.rb
+++ b/app/lib/bill_parser.rb
@@ -48,8 +48,8 @@ class BillParser
           title:                    contents[2],
           proposer:                 proposer_name,
           discussed_session_number: current_session_number,
-          honbun:                   BillUri.honbun_url(contents[0], proposer_id, contents[1]),
           proposal:                 BillUri.proposal_url(contents[0], proposer_id, contents[1]),
+          outline:                  BillUri.outline_url(contents[0], proposer_id, contents[1]),
           status:                   contents[3]
         }
       end

--- a/app/lib/bill_uri.rb
+++ b/app/lib/bill_uri.rb
@@ -9,12 +9,12 @@ class BillUri
       numbers.map { BILLS_URI_PREFIX + "kaiji#{_1}.htm" }
     end
 
-    def honbun_url(submitted_session_number, proposer_id, bill_number)
-      BILLS_URI_PREFIX + "honbun/g" + bill_page_number(submitted_session_number, proposer_id, bill_number) + ".htm"
-    end
-
     def proposal_url(submitted_session_number, proposer_id, bill_number)
       BILLS_URI_PREFIX + "honbun/houan/g" + bill_page_number(submitted_session_number, proposer_id, bill_number) + ".htm"
+    end
+
+    def outline_url(submitted_session_number, proposer_id, bill_number)
+      BILLS_URI_PREFIX + "youkou/g" + bill_page_number(submitted_session_number, proposer_id, bill_number) + ".htm"
     end
 
     private

--- a/app/views/bills/show.html.slim
+++ b/app/views/bills/show.html.slim
@@ -24,9 +24,9 @@ article
           tr
             td = t(".link") + ": "
             td 
-              = link_to t(".honbun"), @bill.honbun
-              br
               = link_to t(".proposal"), @bill.proposal
+              br
+              = link_to t(".outline"), @bill.outline
 
     = link_to t(".back"), bills_path
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -11,8 +11,8 @@ ja:
         bill_number: "議案番号"
         proposer: "提案元"
         status: "審議状況"
-        honbun: "議案本文情報"
         proposal: "提出時法案"
+        outline: "要綱"
       comment:
         description: コメント文
   bills:
@@ -35,8 +35,8 @@ ja:
       submitted_session: "提出会期"
       discussed_session: "審議会期"
       bill_number: "議案番号"
-      honbun: "議案本文情報"
       proposal: "提出時法律案"
+      outline: "要綱"
       status: "審議状況"
       link: "リンク"
       comment_title: "コメント"

--- a/db/migrate/20210218220428_remove_outline_from_and_add_honbun_to_bill.rb
+++ b/db/migrate/20210218220428_remove_outline_from_and_add_honbun_to_bill.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-class RemoveOutlineFromAndAddHonbunToBill < ActiveRecord::Migration[6.0]
-  def change
-    add_column    :bills, :honbun,  :text
-    remove_column :bills, :outline, :text
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_18_220428) do
+ActiveRecord::Schema.define(version: 2020_06_08_141111) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -40,11 +40,11 @@ ActiveRecord::Schema.define(version: 2021_02_18_220428) do
     t.integer "submitted_session_number"
     t.integer "bill_number"
     t.text "proposal"
+    t.text "outline"
     t.text "status"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "discussed_session_number"
-    t.text "honbun"
   end
 
   create_table "comments", force: :cascade do |t|

--- a/test/fixtures/bills.yml
+++ b/test/fixtures/bills.yml
@@ -6,8 +6,8 @@ one:
   submitted_session_number: 1
   discussed_session_number: 1
   bill_number: 1
-  honbun: MyText
   proposal: MyText
+  outline: MyText
   status: MyText
 
 two:
@@ -16,6 +16,6 @@ two:
   submitted_session_number: 1
   discussed_session_number: 1
   bill_number: 1
-  honbun: MyText
   proposal: MyText
+  outline: MyText
   status: MyText

--- a/test/lib/bill_parser_test.rb
+++ b/test/lib/bill_parser_test.rb
@@ -11,8 +11,8 @@ class BillParserTest < ActiveSupport::TestCase
       title: "公文書等の管理に関する法律の一部を改正する法律案",
       proposer: "衆議院",
       discussed_session_number: "201",
-      honbun:   "http://www.shugiin.go.jp/internet/itdb_gian.nsf/html/gian/honbun/g19505004.htm",
       proposal: "http://www.shugiin.go.jp/internet/itdb_gian.nsf/html/gian/honbun/houan/g19505004.htm",
+      outline: "http://www.shugiin.go.jp/internet/itdb_gian.nsf/html/gian/youkou/g19505004.htm",
       status: "衆議院で審議中"
     }
     last_bill = {
@@ -21,8 +21,8 @@ class BillParserTest < ActiveSupport::TestCase
       title: "地方公務員法の一部を改正する法律案",
       proposer: "内閣",
       discussed_session_number: "201",
-      honbun:   "http://www.shugiin.go.jp/internet/itdb_gian.nsf/html/gian/honbun/g20109053.htm",
       proposal: "http://www.shugiin.go.jp/internet/itdb_gian.nsf/html/gian/honbun/houan/g20109053.htm",
+      outline: "http://www.shugiin.go.jp/internet/itdb_gian.nsf/html/gian/youkou/g20109053.htm",
       status: "衆議院で審議中"
     }
     bills = BillParser.bills(PAGE)


### PR DESCRIPTION
本番環境でリンクが正しく貼れていない

<img width="1436" alt="スクリーンショット 2021-02-19 8 40 25" src="https://user-images.githubusercontent.com/48672932/108436088-1fd66980-728e-11eb-8213-39fc60035d4e.png">
