### PR TITLE
capistranoのバージョン指定を修正

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # config valid for current version and patch releases of Capistrano
-lock "~> 3.15.0"
+lock "~> 3.16.0"
 
 set :application, "bill_watcher"
 set :repo_url, "git@github.com:chihaso/bill_watcher.git"


### PR DESCRIPTION
- セキュリティアラートに基づくバージョンアップによりdeploy.rb作作成時とcapistranoのバージョンが異なるため