### PR TITLE
本文情報のページ等のリンク生成処理の修正

### DIFF
--- a/app/lib/bill_parser.rb
+++ b/app/lib/bill_parser.rb
@@ -48,8 +48,8 @@ class BillParser
           title:                    contents[2],
           proposer:                 proposer_name,
           discussed_session_number: current_session_number,
-          honbun:                   BillUri.honbun_url(contents[0], proposer_id, contents[1]),
-          proposal:                 BillUri.proposal_url(contents[0], proposer_id, contents[1]),
+          honbun:                   honbun_url(contents[5]),
+          proposal:                 proposal_url(contents[5]),
           status:                   contents[3]
         }
       end
@@ -64,6 +64,19 @@ class BillParser
 
       def content_in_field(field)
         field.match(%r{<span.*?>(.*?)</span>}).captures[0]
+      end
+
+      def honbun_url(content)
+        extract_href(content) ? BillUri.honbun_url(extract_href(content)) : nil
+      end
+
+      def proposal_url(content)
+        extract_href(content) ? BillUri.proposal_url(extract_href(content)) : nil
+      end
+
+      def extract_href(anchor)
+        match = anchor.match(%r{<a.*?href="./(.*?)".*?>.*?</a>})
+        match ? match.captures[0] : nil
       end
   end
 end

--- a/app/lib/bill_scrapper.rb
+++ b/app/lib/bill_scrapper.rb
@@ -8,6 +8,12 @@ class BillScrapper
       all_bill_pages.flat_map { BillParser.bills(_1) }
     end
 
+    # 開発用
+    def specified_sessions(discussed_session_numbers)
+      pages = BillUri.session_urls(discussed_session_numbers).map { read_as_cp932(_1) }
+      pages.flat_map { BillParser.bills(_1) }
+    end
+
     private
       def all_bill_pages
         @bill_pages ||=

--- a/app/lib/bill_uri.rb
+++ b/app/lib/bill_uri.rb
@@ -9,12 +9,12 @@ class BillUri
       numbers.map { BILLS_URI_PREFIX + "kaiji#{_1}.htm" }
     end
 
-    def honbun_url(submitted_session_number, proposer_id, bill_number)
-      BILLS_URI_PREFIX + "honbun/g" + bill_page_number(submitted_session_number, proposer_id, bill_number) + ".htm"
+    def honbun_url(relative_path)
+      BILLS_URI_PREFIX + relative_path
     end
 
-    def proposal_url(submitted_session_number, proposer_id, bill_number)
-      BILLS_URI_PREFIX + "honbun/houan/g" + bill_page_number(submitted_session_number, proposer_id, bill_number) + ".htm"
+    def proposal_url(honbun_relative_path)
+      BILLS_URI_PREFIX + "honbun/houan/" + honbun_relative_path.split("/").last
     end
 
     private

--- a/app/models/bill.rb
+++ b/app/models/bill.rb
@@ -10,6 +10,13 @@ class Bill < ApplicationRecord
       end
     end
 
+    # 開発用（引数は配列で渡すこと）
+    def update_specified_sessions(discussed_session_numbers)
+      BillScrapper.specified_sessions(discussed_session_numbers).each do |bill|
+        Bill.find_or_initialize_by(existing_check_hash(bill)).update(bill)
+      end
+    end
+
     private
       def existing_check_hash(bill)
         {

--- a/app/views/bills/show.html.slim
+++ b/app/views/bills/show.html.slim
@@ -24,9 +24,9 @@ article
           tr
             td = t(".link") + ": "
             td 
-              = link_to t(".honbun"), @bill.honbun
+              = @bill.honbun ? link_to(t(".honbun"), @bill.honbun) : ""
               br
-              = link_to t(".proposal"), @bill.proposal
+              = @bill.proposal ? link_to(t(".proposal"), @bill.proposal) : ""
 
     = link_to t(".back"), bills_path
 


### PR DESCRIPTION
close #125

## 概要
- 衆議院のページで議案番号が空欄になっているものや、回次が古いもの（141以前？）の中には本文リンクがないものがあり、その場合は従来の実装だとリンククリック時に404が返ってしまうのでリンク生成処理を修正する
- 現状、本文情報ページのURLは議案番号から生成しているが、上記の通り議案番号がない場合があるので、各会期の議案一覧ページにあるリンクからURLを直接抽出する
- 提出時法案ページのURLは、本文情報ページのURLから生成する
- 上記の通りそもそも本文情報ページが存在しない議案もあるので、その場合はリンクを非表示にする