### PR TITLE
マイグレーションファイルとschema.rbはほぼ自動生成なのでrubocopのチェック対象から外す

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,8 @@ AllCops:
     - 'actionmailbox/test/dummy/**/*'
     - 'actiontext/test/dummy/**/*'
     - '**/node_modules/**/*'
+    - 'db/migrate/*'
+    - 'db/schema.rb'
 
 Performance:
   Exclude:


### PR DESCRIPTION
close #56 