### PR TITLE
lintとtestをbin配下に追加

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -1,0 +1,1 @@
+bin/bundle exec rubocop -a

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,2 @@
+bin/rails test
+bin/lint


### PR DESCRIPTION
- test時はついでにlintも行う
- lintはrubocopの-aオプション付きで実行