### PR TITLE
議案データ取得時にログに時刻と成否およびエラーメッセージを残す

### DIFF
--- a/app/models/bill.rb
+++ b/app/models/bill.rb
@@ -5,9 +5,14 @@ class Bill < ApplicationRecord
 
   class << self
     def update_all
+      logger.info "議案データの取得を開始" + time_stamp
       BillScrapper.all.each do |bill|
-        Bill.find_or_initialize_by(existing_check_hash(bill)).update(bill)
+        Bill.find_or_initialize_by(existing_check_hash(bill)).update!(bill)
       end
+      logger.info "議案データの更新に成功" + time_stamp
+    rescue =>e
+      logger.error "議案データの更新に失敗" + time_stamp
+      logger.error e.full_message
     end
 
     # 開発用（引数は配列で渡すこと）
@@ -18,6 +23,10 @@ class Bill < ApplicationRecord
     end
 
     private
+      def time_stamp
+        " at " + Time.zone.now.strftime("%F %T %z")
+      end
+
       def existing_check_hash(bill)
         {
           submitted_session_number: bill[:submitted_session_number],

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
+require File.expand_path(File.dirname(__FILE__) + "/environment")
 require "active_support/core_ext/time"
 
-set :output, "/Users/chibayuta/dev/myapps/bill_watcher/tmp/bill_update.log"
+set :output, "#{Rails.root}/log/cron.log"
 set :job_template, nil
 rails_env = ENV["RAILS_ENV"] || "development"
 set :environment, rails_env


### PR DESCRIPTION
close  #61

- もともとcronのログしか残っていなかった上、その出力先も本番環境では不正なパスだったので修正
- 時刻や成否の情報は通常のログファイルに出力する