### PR TITLE
同じユーザーが同じ法案を複数ウォッチできないように制約を追加する

### DIFF
--- a/db/migrate/20220116083213_add_unique_index_to_watches.rb
+++ b/db/migrate/20220116083213_add_unique_index_to_watches.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToWatches < ActiveRecord::Migration[6.1]
+  def change
+    add_index :watches, [:user_id, :bill_id], unique: true 
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_21_133247) do
+ActiveRecord::Schema.define(version: 2022_01_16_083213) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -82,6 +82,7 @@ ActiveRecord::Schema.define(version: 2021_12_21_133247) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["bill_id"], name: "index_watches_on_bill_id"
+    t.index ["user_id", "bill_id"], name: "index_watches_on_user_id_and_bill_id", unique: true
     t.index ["user_id"], name: "index_watches_on_user_id"
   end
 


### PR DESCRIPTION
現状、ウォッチボタンの不具合により、何度も同じ法案をウォッチするリクエストを飛ばすことができるようになっている。
重複に意味はないので、取り急ぎ、重複してウォッチすることができないように制約を追加する